### PR TITLE
Update SSL configuration across services

### DIFF
--- a/admin-service/src/main/resources/application-prod.yml
+++ b/admin-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 server:
   port: 80
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -20,12 +20,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:

--- a/authentication-service/src/main/resources/application-prod.yml
+++ b/authentication-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 server:
   port: 80
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -16,12 +16,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 
 

--- a/chess-service/src/main/resources/application-prod.yml
+++ b/chess-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 server:
   port: 80
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -16,12 +16,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:

--- a/fitness-service/src/main/resources/application-prod.yml
+++ b/fitness-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 server:
   port: 80
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -16,12 +16,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 server:
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -15,12 +15,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:

--- a/registry-service/src/main/resources/application-prod.yml
+++ b/registry-service/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 server:
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -15,12 +15,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:

--- a/usermanagement-service/src/main/resources/application-prod.yml
+++ b/usermanagement-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 server:
   port: 80
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -16,12 +16,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:

--- a/website-service/src/main/resources/application-prod.yml
+++ b/website-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
 server:
   port: 80
   ssl:
-    bundle: “web-server”
+    bundle: "server"
     client-auth: WANT
 
 spring:
@@ -16,12 +16,13 @@ spring:
   ssl:
     bundle:
       jks:
-        web-server:
+        server:
           key:
             alias: "michibaum"
           keystore:
             location: "/data/ssl/keystore.p12"
             password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:


### PR DESCRIPTION
Standardize SSL configuration by changing the bundle name from "web-server" to "server" and adding the keystore type as "PKCS12". This ensures consistency and specifies the keystore type for all services.