### PR TITLE
Switch services to use port 443 for HTTPS

### DIFF
--- a/admin-service/src/main/resources/application-prod.yml
+++ b/admin-service/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 443
   ssl:
     bundle: "server"
     client-auth: WANT

--- a/authentication-service/src/main/resources/application-prod.yml
+++ b/authentication-service/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 443
   ssl:
     bundle: "server"
     client-auth: WANT

--- a/chess-service/src/main/resources/application-prod.yml
+++ b/chess-service/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 443
   ssl:
     bundle: "server"
     client-auth: WANT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
     expose:
-      - "80"
+      - "443"
     volumes:
       - /data/ssl:/data/ssl
     networks:
@@ -63,7 +63,7 @@ services:
       DATABASE_PASSWORD: ${AUTHENTICATION_DB_PASSWORD}
       DATABASE: ${AUTHENTICATION_DB}
     expose:
-      - "80"
+      - "443"
     volumes:
       - /data/ssl:/data/ssl
     networks:
@@ -107,7 +107,7 @@ services:
       DATABASE_PASSWORD: ${USERMANAGEMENT_DB_PASSWORD}
       DATABASE: ${USERMANAGEMENT_DB}
     expose:
-      - "80"
+      - "443"
     volumes:
       - /data/ssl:/data/ssl
     networks:
@@ -148,8 +148,7 @@ services:
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
     ports:
-      - "80:80"
-      - "443:80"
+      - "443:443"
     volumes:
       - /data/ssl:/data/ssl
     networks:
@@ -174,7 +173,7 @@ services:
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
     expose:
-      - "80"
+      - "443"
     volumes:
       - /data/ssl:/data/ssl
     networks:
@@ -202,7 +201,7 @@ services:
       DATABASE_PASSWORD: ${CHESS_DB_PASSWORD}
       DATABASE: ${CHESS_DB}
     expose:
-      - "80"
+      - "443"
     volumes:
       - /data/ssl:/data/ssl
     networks:
@@ -246,7 +245,7 @@ services:
       DATABASE_PASSWORD: ${FITNESS_DB_PASSWORD}
       DATABASE: ${FITNESS_DB}
     expose:
-      - "80"
+      - "443"
     volumes:
       - /data/ssl:/data/ssl
     networks:

--- a/fitness-service/src/main/resources/application-prod.yml
+++ b/fitness-service/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 443
   ssl:
     bundle: "server"
     client-auth: WANT

--- a/gateway-service/src/main/resources/application-dev.yml
+++ b/gateway-service/src/main/resources/application-dev.yml
@@ -1,3 +1,6 @@
+server:
+  port: 80
+
 eureka:
   client:
     service-url:

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -1,4 +1,5 @@
 server:
+  port: 443
   ssl:
     bundle: "server"
     client-auth: WANT

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -2,7 +2,6 @@ server:
   shutdown: graceful
   undertow:
     url-charset: UTF-8
-  port: 80
 
 spring:
   threads:

--- a/usermanagement-service/src/main/resources/application-prod.yml
+++ b/usermanagement-service/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 443
   ssl:
     bundle: "server"
     client-auth: WANT

--- a/website-service/src/main/resources/application-prod.yml
+++ b/website-service/src/main/resources/application-prod.yml
@@ -1,5 +1,5 @@
 server:
-  port: 80
+  port: 443
   ssl:
     bundle: "server"
     client-auth: WANT


### PR DESCRIPTION
Changed server ports from 80 to 443 across multiple services and the docker-compose file to enforce HTTPS. This update enhances security by ensuring secure communication channels via SSL/TLS encryption.