### PR TITLE
Enable HTTPS and secure ports for services

### DIFF
--- a/admin-service/src/main/resources/application-prod.yml
+++ b/admin-service/src/main/resources/application-prod.yml
@@ -31,4 +31,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false

--- a/authentication-service/src/main/resources/application-prod.yml
+++ b/authentication-service/src/main/resources/application-prod.yml
@@ -29,4 +29,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false

--- a/chess-service/src/main/resources/application-prod.yml
+++ b/chess-service/src/main/resources/application-prod.yml
@@ -27,4 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false

--- a/fitness-service/src/main/resources/application-prod.yml
+++ b/fitness-service/src/main/resources/application-prod.yml
@@ -27,4 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -27,4 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false

--- a/registry-service/src/main/resources/application-prod.yml
+++ b/registry-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
-#server:
-#  ssl:
-#    bundle: "server"
-#    client-auth: WANT
+server:
+  ssl:
+    bundle: "server"
+    client-auth: WANT
 
 spring:
   microservices:
@@ -12,18 +12,21 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_REGISTRY_SERVICE_LOG_CHANNEL}
-#  ssl:
-#    bundle:
-#      jks:
-#        server:
-#          key:
-#            alias: "michibaum"
-#          keystore:
-#            location: "/data/ssl/keystore.p12"
-#            password: ${SSL_KEYSTORE_PASSWORD}
-#            type: "PKCS12"
+  ssl:
+    bundle:
+      jks:
+        server:
+          key:
+            alias: "michibaum"
+          keystore:
+            location: "/data/ssl/keystore.p12"
+            password: ${SSL_KEYSTORE_PASSWORD}
+            type: "PKCS12"
 
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false

--- a/usermanagement-service/src/main/resources/application-prod.yml
+++ b/usermanagement-service/src/main/resources/application-prod.yml
@@ -27,4 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false

--- a/website-service/src/main/resources/application-prod.yml
+++ b/website-service/src/main/resources/application-prod.yml
@@ -27,4 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://registry-service:8761/eureka
+      defaultZone: https://registry-service:8761/eureka
+  instance:
+    secure-port-enabled: true
+    non-secure-port-enabled: false


### PR DESCRIPTION
Updated several service configurations to use HTTPS for Eureka client connections and enabled secure ports while disabling non-secure ports. This enhances communication security across services in the production environment.