### PR TITLE
Switch Eureka URLs to HTTP

### DIFF
--- a/admin-service/src/main/resources/application-prod.yml
+++ b/admin-service/src/main/resources/application-prod.yml
@@ -31,7 +31,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false

--- a/authentication-service/src/main/resources/application-prod.yml
+++ b/authentication-service/src/main/resources/application-prod.yml
@@ -29,7 +29,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false

--- a/chess-service/src/main/resources/application-prod.yml
+++ b/chess-service/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false

--- a/fitness-service/src/main/resources/application-prod.yml
+++ b/fitness-service/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false

--- a/registry-service/src/main/resources/application-prod.yml
+++ b/registry-service/src/main/resources/application-prod.yml
@@ -1,7 +1,7 @@
-server:
-  ssl:
-    bundle: "server"
-    client-auth: WANT
+#server:
+#  ssl:
+#    bundle: "server"
+#    client-auth: WANT
 
 spring:
   microservices:
@@ -12,21 +12,21 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_REGISTRY_SERVICE_LOG_CHANNEL}
-  ssl:
-    bundle:
-      jks:
-        server:
-          key:
-            alias: "michibaum"
-          keystore:
-            location: "/data/ssl/keystore.p12"
-            password: ${SSL_KEYSTORE_PASSWORD}
-            type: "PKCS12"
+#  ssl:
+#    bundle:
+#      jks:
+#        server:
+#          key:
+#            alias: "michibaum"
+#          keystore:
+#            location: "/data/ssl/keystore.p12"
+#            password: ${SSL_KEYSTORE_PASSWORD}
+#            type: "PKCS12"
 
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false

--- a/usermanagement-service/src/main/resources/application-prod.yml
+++ b/usermanagement-service/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false

--- a/website-service/src/main/resources/application-prod.yml
+++ b/website-service/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: https://registry-service:8761/eureka
+      defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
     non-secure-port-enabled: false


### PR DESCRIPTION
Changed all service configurations to use HTTP instead of HTTPS for the Eureka defaultZone URL. Commented out SSL configurations in registry-service to avoid SSL-related issues. This ensures consistency across service configurations and resolves potential connectivity problems.