### PR TITLE
Enable non-secure ports in production config

### DIFF
--- a/admin-service/src/main/resources/application-prod.yml
+++ b/admin-service/src/main/resources/application-prod.yml
@@ -34,4 +34,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true

--- a/authentication-service/src/main/resources/application-prod.yml
+++ b/authentication-service/src/main/resources/application-prod.yml
@@ -32,4 +32,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true

--- a/chess-service/src/main/resources/application-prod.yml
+++ b/chess-service/src/main/resources/application-prod.yml
@@ -30,4 +30,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true

--- a/fitness-service/src/main/resources/application-prod.yml
+++ b/fitness-service/src/main/resources/application-prod.yml
@@ -30,4 +30,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -30,4 +30,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true

--- a/registry-service/src/main/resources/application-prod.yml
+++ b/registry-service/src/main/resources/application-prod.yml
@@ -29,4 +29,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true

--- a/usermanagement-service/src/main/resources/application-prod.yml
+++ b/usermanagement-service/src/main/resources/application-prod.yml
@@ -30,4 +30,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true

--- a/website-service/src/main/resources/application-prod.yml
+++ b/website-service/src/main/resources/application-prod.yml
@@ -30,4 +30,4 @@ eureka:
       defaultZone: http://registry-service:8761/eureka
   instance:
     secure-port-enabled: true
-    non-secure-port-enabled: false
+    non-secure-port-enabled: true


### PR DESCRIPTION
Updated application-prod.yml for multiple services to enable non-secure ports for instances. This adjustment allows more flexibility in network configurations and testing environments.