### PR TITLE
Switch to HTTP and remove SSL configurations

### DIFF
--- a/admin-service/src/main/resources/application-prod.yml
+++ b/admin-service/src/main/resources/application-prod.yml
@@ -1,8 +1,5 @@
 server:
-  port: 443
-  ssl:
-    bundle: "server"
-    client-auth: WANT
+  port: 80
 
 spring:
   microservices:
@@ -16,22 +13,9 @@ spring:
   boot:
     admin:
       ui:
-        public-url: http://admin.michibaum.ch
-  ssl:
-    bundle:
-      jks:
-        server:
-          key:
-            alias: "michibaum"
-          keystore:
-            location: "/data/ssl/keystore.p12"
-            password: ${SSL_KEYSTORE_PASSWORD}
-            type: "PKCS12"
+        public-url: https://admin.michibaum.ch
 
 eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true

--- a/authentication-service/src/main/resources/application-prod.yml
+++ b/authentication-service/src/main/resources/application-prod.yml
@@ -1,8 +1,5 @@
 server:
-  port: 443
-  ssl:
-    bundle: "server"
-    client-auth: WANT
+  port: 80
 
 spring:
   microservices:
@@ -13,23 +10,8 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_AUTHENTICATION_SERVICE_LOG_CHANNEL}
-  ssl:
-    bundle:
-      jks:
-        server:
-          key:
-            alias: "michibaum"
-          keystore:
-            location: "/data/ssl/keystore.p12"
-            password: ${SSL_KEYSTORE_PASSWORD}
-            type: "PKCS12"
-
-
 
 eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true

--- a/chess-service/src/main/resources/application-prod.yml
+++ b/chess-service/src/main/resources/application-prod.yml
@@ -1,8 +1,5 @@
 server:
-  port: 443
-  ssl:
-    bundle: "server"
-    client-auth: WANT
+  port: 80
 
 spring:
   microservices:
@@ -13,21 +10,8 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_CHESS_SERVICE_LOG_CHANNEL}
-  ssl:
-    bundle:
-      jks:
-        server:
-          key:
-            alias: "michibaum"
-          keystore:
-            location: "/data/ssl/keystore.p12"
-            password: ${SSL_KEYSTORE_PASSWORD}
-            type: "PKCS12"
 
 eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
     expose:
       - "8761"
-    volumes:
-      - /data/ssl:/data/ssl
     networks:
       - microservice-network
     deploy:
@@ -36,9 +34,7 @@ services:
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
     expose:
-      - "443"
-    volumes:
-      - /data/ssl:/data/ssl
+      - "80"
     networks:
       - microservice-network
     deploy:
@@ -63,9 +59,7 @@ services:
       DATABASE_PASSWORD: ${AUTHENTICATION_DB_PASSWORD}
       DATABASE: ${AUTHENTICATION_DB}
     expose:
-      - "443"
-    volumes:
-      - /data/ssl:/data/ssl
+      - "80"
     networks:
       - microservice-network
     deploy:
@@ -107,9 +101,7 @@ services:
       DATABASE_PASSWORD: ${USERMANAGEMENT_DB_PASSWORD}
       DATABASE: ${USERMANAGEMENT_DB}
     expose:
-      - "443"
-    volumes:
-      - /data/ssl:/data/ssl
+      - "80"
     networks:
       - microservice-network
     deploy:
@@ -173,9 +165,7 @@ services:
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
     expose:
-      - "443"
-    volumes:
-      - /data/ssl:/data/ssl
+      - "80"
     networks:
       - microservice-network
     deploy:
@@ -201,9 +191,7 @@ services:
       DATABASE_PASSWORD: ${CHESS_DB_PASSWORD}
       DATABASE: ${CHESS_DB}
     expose:
-      - "443"
-    volumes:
-      - /data/ssl:/data/ssl
+      - "80"
     networks:
       - microservice-network
     deploy:
@@ -245,9 +233,7 @@ services:
       DATABASE_PASSWORD: ${FITNESS_DB_PASSWORD}
       DATABASE: ${FITNESS_DB}
     expose:
-      - "443"
-    volumes:
-      - /data/ssl:/data/ssl
+      - "80"
     networks:
       - microservice-network
     deploy:

--- a/fitness-service/src/main/resources/application-prod.yml
+++ b/fitness-service/src/main/resources/application-prod.yml
@@ -1,8 +1,5 @@
 server:
-  port: 443
-  ssl:
-    bundle: "server"
-    client-auth: WANT
+  port: 80
 
 spring:
   microservices:
@@ -13,21 +10,8 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_FITNESS_SERVICE_LOG_CHANNEL}
-  ssl:
-    bundle:
-      jks:
-        server:
-          key:
-            alias: "michibaum"
-          keystore:
-            location: "/data/ssl/keystore.p12"
-            password: ${SSL_KEYSTORE_PASSWORD}
-            type: "PKCS12"
 
 eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -28,6 +28,3 @@ eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true

--- a/registry-service/src/main/resources/application-prod.yml
+++ b/registry-service/src/main/resources/application-prod.yml
@@ -1,8 +1,3 @@
-#server:
-#  ssl:
-#    bundle: "server"
-#    client-auth: WANT
-
 spring:
   microservices:
     discord:
@@ -12,21 +7,8 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_REGISTRY_SERVICE_LOG_CHANNEL}
-#  ssl:
-#    bundle:
-#      jks:
-#        server:
-#          key:
-#            alias: "michibaum"
-#          keystore:
-#            location: "/data/ssl/keystore.p12"
-#            password: ${SSL_KEYSTORE_PASSWORD}
-#            type: "PKCS12"
 
 eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true

--- a/usermanagement-service/src/main/resources/application-prod.yml
+++ b/usermanagement-service/src/main/resources/application-prod.yml
@@ -1,8 +1,5 @@
 server:
-  port: 443
-  ssl:
-    bundle: "server"
-    client-auth: WANT
+  port: 80
 
 spring:
   microservices:
@@ -13,21 +10,8 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_USERMANAGEMENT_SERVICE_LOG_CHANNEL}
-  ssl:
-    bundle:
-      jks:
-        server:
-          key:
-            alias: "michibaum"
-          keystore:
-            location: "/data/ssl/keystore.p12"
-            password: ${SSL_KEYSTORE_PASSWORD}
-            type: "PKCS12"
 
 eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true

--- a/website-service/src/main/resources/application-prod.yml
+++ b/website-service/src/main/resources/application-prod.yml
@@ -1,8 +1,5 @@
 server:
-  port: 443
-  ssl:
-    bundle: "server"
-    client-auth: WANT
+  port: 80
 
 spring:
   microservices:
@@ -13,21 +10,8 @@ spring:
       logging:
         enabled: true
         channel-id: ${DISCORD_WEBSITE_SERVICE_LOG_CHANNEL}
-  ssl:
-    bundle:
-      jks:
-        server:
-          key:
-            alias: "michibaum"
-          keystore:
-            location: "/data/ssl/keystore.p12"
-            password: ${SSL_KEYSTORE_PASSWORD}
-            type: "PKCS12"
 
 eureka:
   client:
     service-url:
       defaultZone: http://registry-service:8761/eureka
-  instance:
-    secure-port-enabled: true
-    non-secure-port-enabled: true


### PR DESCRIPTION
Changed the port from 443 to 80 for multiple services to utilize HTTP instead of HTTPS. Removed SSL-related configurations from `application-prod.yml` files and corresponding volume mappings from `docker-compose.yml`.