### PR TITLE
Fix favicon and manifest paths in config files

### DIFF
--- a/website/angular.json
+++ b/website/angular.json
@@ -30,7 +30,7 @@
             ],
             "tsConfig": "tsconfig.app.json",
             "assets": [
-              "src/favicon.ico",
+              "src/manifest.webmanifest",
               "src/assets"
             ],
             "styles": [

--- a/website/ngsw-config.json
+++ b/website/ngsw-config.json
@@ -7,7 +7,7 @@
       "installMode": "prefetch",
       "resources": {
         "files": [
-          "/favicon.ico",
+          "/assets/icons/favicon.ico",
           "/index.html",
           "/manifest.webmanifest",
           "/*.css",


### PR DESCRIPTION
This commit changes the path for favicon.ico in ngsw-config.json to point to /assets/icons/favicon.ico. Additionally, it updates the angular.json file to include manifest.webmanifest in the assets section instead of the favicon.