### PR TITLE
Add port mappings for database services in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       MARIADB_DATABASE: ${AUTHENTICATION_DB}
     expose:
       - "3306"
+    ports:
+      - "127.0.0.1:3307:3306"
     volumes:
       - /data/authentication-db:/var/lib/mysql
     networks:
@@ -92,6 +94,8 @@ services:
       MARIADB_DATABASE: ${USERMANAGEMENT_DB}
     expose:
       - "3306"
+    ports:
+      - "127.0.0.1:3308:3306"
     volumes:
       - /data/usermanagement-db:/var/lib/mysql
     networks:
@@ -157,6 +161,8 @@ services:
       MARIADB_DATABASE: ${CHESS_DB}
     expose:
       - "3306"
+    ports:
+      - "127.0.0.1:3309:3306"
     volumes:
       - /data/chess-db:/var/lib/mysql
     networks:
@@ -192,6 +198,8 @@ services:
       MARIADB_DATABASE: ${FITNESS_DB}
     expose:
       - "3306"
+    ports:
+      - "127.0.0.1:3310:3306"
     volumes:
       - /data/fitness-db:/var/lib/mysql
     networks:


### PR DESCRIPTION
This change adds specific port mappings for each MariaDB service to allow local host access. The mappings are set to localhost with incremented ports starting from 3307, ensuring each service is uniquely accessible. This enhancement helps in development by making it easier to connect to each database individually.