### PR TITLE
Fix Add JwsValidator import in AuthenticationGatewayFilterFactory

### DIFF
--- a/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/AuthenticationGatewayFilterFactory.kt
+++ b/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/AuthenticationGatewayFilterFactory.kt
@@ -1,5 +1,6 @@
 package com.michibaum.gatewayservice
 
+import com.michibaum.authentication_library.security.netty.JwsValidator
 import org.springframework.cloud.gateway.filter.GatewayFilter
 import org.springframework.cloud.gateway.filter.GatewayFilterChain
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory


### PR DESCRIPTION
This commit introduces an import statement for JwsValidator from the authentication library. This change is necessary to facilitate JWT validation functionality within the authentication gateway filter.