### PR TITLE
Fix Add JwsValidator import to AuthenticationGatewayFilterIT

### DIFF
--- a/gateway-service/src/test/kotlin/com/michibaum/gatewayservice/AuthenticationGatewayFilterIT.kt
+++ b/gateway-service/src/test/kotlin/com/michibaum/gatewayservice/AuthenticationGatewayFilterIT.kt
@@ -3,6 +3,7 @@ package com.michibaum.gatewayservice
 import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import com.michibaum.authentication_library.security.netty.JwsValidator
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension


### PR DESCRIPTION
This change ensures that the JwsValidator class is available for authentication tests. It helps in maintaining the test accuracy and reliability by using the necessary security components.