### PR TITLE
Enable SSL validation and update docker-compose configuration.

### DIFF
--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -34,6 +34,8 @@ spring:
           include-description: true
     openfeign:
       lazy-attributes-resolution: true
+      httpclient:
+        disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
 

--- a/authentication-service/src/main/resources/application.yml
+++ b/authentication-service/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
           include-description: true
     openfeign:
       lazy-attributes-resolution: true
+      httpclient:
+        disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
 

--- a/chess-service/src/main/resources/application.yml
+++ b/chess-service/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
           include-description: true
     openfeign:
       lazy-attributes-resolution: true
+      httpclient:
+        disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   registry-service:

--- a/fitness-service/src/main/resources/application.yml
+++ b/fitness-service/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
           include-description: true
     openfeign:
       lazy-attributes-resolution: true
+      httpclient:
+        disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
 

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -2,7 +2,7 @@ server:
   port: 443
   ssl:
     bundle: "server"
-    client-auth: WANT
+    enabled: true
   http2:
     enabled: true
 

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -56,6 +56,8 @@ spring:
           include-description: true
     openfeign:
       lazy-attributes-resolution: true
+      httpclient:
+        disable-ssl-validation: true
 
   main:
     allow-bean-definition-overriding: true

--- a/usermanagement-service/src/main/resources/application.yml
+++ b/usermanagement-service/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
           include-description: true
     openfeign:
       lazy-attributes-resolution: true
+      httpclient:
+        disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
 


### PR DESCRIPTION
Added configurations to disable SSL validation for OpenFeign HTTP client across multiple services. Also corrected SSL settings for the gateway service in production. Removed version specification from docker-compose.yml.