### PR TITLE
develop

### DIFF
--- a/authentication-library/src/main/kotlin/com/michibaum/authentication_library/JwsValidator.kt
+++ b/authentication-library/src/main/kotlin/com/michibaum/authentication_library/JwsValidator.kt
@@ -6,8 +6,10 @@ import com.auth0.jwt.exceptions.JWTVerificationException
 import java.security.interfaces.RSAPublicKey
 
 open class JwsValidator {
-    fun validate(token: String, publicKey: RSAPublicKey): Boolean {
+    fun validate(token: String, publicKey: RSAPublicKey?): Boolean {
         try {
+            if (publicKey == null)
+                return false
             val algorithm = JwsAlgorithm.algorithm(publicKey)
             val verifier: JWTVerifier = JWT.require(algorithm)
                     .withIssuer("authentication-service")

--- a/authentication-library/src/main/kotlin/com/michibaum/authentication_library/security/jwt/JwsValidator.kt
+++ b/authentication-library/src/main/kotlin/com/michibaum/authentication_library/security/jwt/JwsValidator.kt
@@ -17,7 +17,13 @@ class JwsValidator(
 
     val logger = org.slf4j.LoggerFactory.getLogger(this.javaClass)
 
-    private lateinit var publicKey: RSAPublicKey
+    private var publicKey: RSAPublicKey? = null
+        get() {
+            if (field == null) {
+                reloadPublicKey()
+            }
+            return field
+        }
 
     fun reloadPublicKey() {
         val dto = try {

--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/AuthenticationServiceApplication.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/AuthenticationServiceApplication.kt
@@ -10,7 +10,7 @@ import org.springframework.boot.runApplication
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableScheduling
-@EnableFeignClients(basePackages = ["com.michibaum.usermanagement_library", "com.michibaum.authentication_library"])
+@EnableFeignClients(basePackages = ["com.michibaum.usermanagement_library"])
 class AuthenticationServiceApplication
 
 fun main(args: Array<String>) {

--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/authentication/AuthenticationController.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/authentication/AuthenticationController.kt
@@ -33,8 +33,10 @@ class AuthenticationController (
         val jws = authenticationService.generateJWS(userDetailsDto)!!
 
         val cookie = ResponseCookie.from("jwt", jws)
-            .httpOnly(true)
-            .domain(".michibaum.ch") // TODO secure
+//            .httpOnly(true)
+            .domain(".michibaum.ch")
+            .secure(true)
+            .sameSite("None")
             .build()
 
         val responseBody = AuthenticationResponse(authenticationDto.username, jws)

--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityBeansConfiguration.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,7 @@
 package com.michibaum.authentication_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.PublicKeyDto
 import com.michibaum.authentication_library.security.ReactiveDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
 import com.michibaum.authentication_library.security.basic.netty.BasicAuthenticationConverter
@@ -9,6 +10,7 @@ import com.michibaum.authentication_library.security.basic.CredentialsValidator
 import com.michibaum.authentication_library.security.jwt.JwsValidator
 import com.michibaum.authentication_library.security.jwt.netty.JwtAuthenticationConverter
 import com.michibaum.authentication_library.security.jwt.JwtAuthenticationManager
+import com.michibaum.authentication_service.authentication.AuthenticationService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
@@ -25,8 +27,14 @@ class SecurityBeansConfiguration {
 
 
     @Bean
-    fun jwsValidator(@Lazy authenticationClient: AuthenticationClient): JwsValidator =
-        JwsValidator(authenticationClient)
+    fun jwsValidator(authenticationService: AuthenticationService): JwsValidator {
+        val authenticationClient = object: AuthenticationClient{
+            override fun publicKey(): PublicKeyDto {
+                return authenticationService.publicKey
+            }
+        }
+        return JwsValidator(authenticationClient)
+    }
 
     @Bean
     fun credentialsValidator(adminServiceCredentials: AdminServiceCredentials): CredentialsValidator =

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -18,14 +18,14 @@ spring:
           uri: lb://admin-service
           predicates:
             - Host=admin.michibaum.ch
-#          filters:
-#            - Authentication
+          filters:
+            - Authentication
         - id: registry
           uri: lb://registry-service
           predicates:
             - Host=registry.michibaum.ch
-#          filters:
-#            - Authentication
+          filters:
+            - Authentication
         - id: authentication
           uri: lb://authentication-service
           predicates:

--- a/website-service/src/main/kotlin/com/michibaum/websiteservice/security/SecurityBeansConfiguration.kt
+++ b/website-service/src/main/kotlin/com/michibaum/websiteservice/security/SecurityBeansConfiguration.kt
@@ -14,10 +14,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Lazy
 import org.springframework.security.authentication.AuthenticationManager
-import org.springframework.security.authentication.AuthenticationProvider
-import org.springframework.security.authentication.ProviderManager
 import org.springframework.security.web.authentication.AuthenticationConverter
-import org.springframework.security.web.authentication.AuthenticationFilter
 
 
 @Configuration


### PR DESCRIPTION
Refactor public key handling and token extraction

Refactored JwsValidator to make publicKey nullable and lazy-loadable. Improved token extraction in AuthenticationGatewayFilterFactory to handle both headers and cookies. Enabled Authentication filter in gateway-service routes configuration.

Refactor JwsValidator initialization and secure cookies

Refactor the JwsValidator bean to use AuthenticationService directly instead of Lazy AuthenticationClient. Additionally, adjust cookie settings for enhanced security, enabling `secure` and `sameSite` attributes. Finally, remove redundant package from @EnableFeignClients annotation.