### PR TITLE
Quick fix: Remove unused key-alias from application-prod.yml

### DIFF
--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -2,7 +2,6 @@ server:
   port: 443
   ssl:
     enabled: true
-    key-alias: server
     bundle: "server"
     key-store-password: ${SSL_KEYSTORE_PASSWORD}
     key-store: "/data/ssl/keystore.p12"


### PR DESCRIPTION
The key-alias property was redundant and has been removed to simplify the SSL configuration. This change does not affect the existing functionality as the SSL setup continues to use the bundle and key-store properties effectively.