### PR TITLE
Enable Flyway migrations and add initial database schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,20 @@ File: */etc/hosts*
 
 ## Local dev db
 
-    docker run --name microservices -e MARIADB_ROOT_PASSWORD=someRootPass -p 3306:3306 -d mariadb:lts-noble
+    docker run --name microservices -e MARIADB_ROOT_PASSWORD=someRootPass -p 3306:3306 -d mariadb:10.11
 
 After that create the databases in the container.
-The tables are created trough
 
-    spring
-      jpa:
-        hibernate:
-          ddl-auto: update
+```
+create schema `authentication-db`;
+create schema `chess-db`;
+create schema `fitness-db`;
+create schema `music-db`;
+create schema `usermanagement-db`;
+```
+
+The tables are created trough [flyway](https://documentation.red-gate.com/fd/migrations-184127470.html).
+
 
 ## License
 

--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -62,6 +62,10 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/authentication-service/src/main/resources/application-dev.yml
+++ b/authentication-service/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
     url: jdbc:mariadb://localhost:3306/authentication-db
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/authentication-service/src/main/resources/application-prod.yml
+++ b/authentication-service/src/main/resources/application-prod.yml
@@ -9,7 +9,7 @@ spring:
     url: jdbc:mariadb://authentication-db:3306/${DATABASE}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/authentication-service/src/main/resources/application.yml
+++ b/authentication-service/src/main/resources/application.yml
@@ -22,6 +22,14 @@ spring:
         disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
+  flyway:
+    enabled: true
+    baselineOnMigrate: true
+    validateOnMigrate: true
+    locations: classpath:db/migration
+    driver-class-name: org.mariadb.jdbc.Driver
+
+
 
 eureka:
   instance:

--- a/chess-service/pom.xml
+++ b/chess-service/pom.xml
@@ -56,6 +56,10 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/chess-service/src/main/resources/application-dev.yml
+++ b/chess-service/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
     url: jdbc:mariadb://localhost:3306/chess-db
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/chess-service/src/main/resources/application-prod.yml
+++ b/chess-service/src/main/resources/application-prod.yml
@@ -9,7 +9,7 @@ spring:
     url: jdbc:mariadb://chess-db:3306/${DATABASE}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/chess-service/src/main/resources/application.yml
+++ b/chess-service/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
         disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
+  flyway:
+    enabled: true
+    baselineOnMigrate: true
+    validateOnMigrate: true
+    locations: classpath:db/migration
+    driver-class-name: org.mariadb.jdbc.Driver
 
 eureka:
   instance:

--- a/chess-service/src/main/resources/db/migration/V1__initialschema.sql
+++ b/chess-service/src/main/resources/db/migration/V1__initialschema.sql
@@ -1,0 +1,91 @@
+create table event
+(
+    id uuid not null primary key,
+    date_from date not null,
+    date_to date not null,
+    embed_url varchar(255) null,
+    location varchar(255) null,
+    title varchar(255) not null,
+    url varchar(255) null
+);
+
+create table event_category
+(
+    id uuid not null primary key,
+    description varchar(255) not null,
+    name varchar(255) not null
+);
+
+create table event_category_mapping
+(
+    category_id uuid not null,
+    event_id uuid not null,
+    primary key (category_id, event_id),
+    constraint FK5dakbhiaox4y3375rth9tc2sg foreign key (category_id) references event_category (id),
+    constraint FKppj0dpllus3pjunrf6ulykq8r foreign key (event_id) references event (id)
+);
+
+create table game
+(
+    event_id uuid null,
+    id uuid not null primary key,
+    opening_name varchar(255) null,
+    platform_id varchar(255) not null,
+    chess_platform enum('CHESSCOM', 'LICHESS', 'OVER_THE_BOARD') null,
+    game_type enum('BLITZ', 'BULLET', 'CLASSICAL', 'RAPID', 'UNKNOWN') null,
+    pgn text not null,
+    constraint FKnqufihgcswqe5fvhkfpuj7201 foreign key (event_id) references event (id)
+);
+
+create table person
+(
+    id uuid not null primary key,
+    birthday date null,
+    federation varchar(255) null,
+    fide_id varchar(255) null,
+    firstname varchar(255) not null,
+    lastname varchar(255) not null,
+    gender enum('FEMALE', 'MALE', 'UNKNOWN') not null
+);
+
+create table account
+(
+    id uuid not null primary key,
+    created_at date null,
+    person_id uuid null,
+    name varchar(255) not null,
+    platform_id varchar(255) not null,
+    url varchar(255) not null,
+    username varchar(255) not null,
+    platform enum('CHESSCOM', 'LICHESS', 'OVER_THE_BOARD') null,
+    constraint FKd9dhia7smrg88vcbiykhofxee foreign key (person_id) references person (id)
+);
+
+create table account_game_mapping
+(
+    account_id uuid not null,
+    game_id uuid not null,
+    primary key (account_id, game_id),
+    constraint FK3xxnwfoji9a57q5gp55cxwip4 foreign key (game_id) references game (id),
+    constraint FKh3ff1qmiwes4gh1venqmh1v57 foreign key (account_id) references account (id)
+);
+
+create table event_participants_mapping
+(
+    event_id uuid not null,
+    person_id uuid not null,
+    primary key (event_id, person_id),
+    constraint FKmaq2jiv6ns0rsyu4bqr3ps225 foreign key (event_id) references event (id),
+    constraint FKq0tjsagris7sowbyylwn6ckma foreign key (person_id) references person (id)
+);
+
+create table player
+(
+    id uuid not null primary key,
+    rating bigint not null,
+    game_id uuid not null,
+    platform_id varchar(255) not null,
+    username varchar(255) not null,
+    piece_color enum('BLACK', 'WHITE') null,
+    constraint FK8095bt0vv5capccv9870ln2n foreign key (game_id) references game (id)
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - microservice-network
 
   authentication-db:
-    image: mariadb:lts-noble
+    image: mariadb:10.11
     env_file:
       - .env
     restart: always
@@ -81,7 +81,7 @@ services:
       - microservice-network
 
   usermanagement-db:
-    image: mariadb:lts-noble
+    image: mariadb:10.11
     env_file:
       - .env
     restart: always
@@ -148,7 +148,7 @@ services:
       - microservice-network
 
   chess-db:
-    image: mariadb:lts-noble
+    image: mariadb:10.11
     env_file:
       - .env
     restart: always
@@ -185,7 +185,7 @@ services:
       - microservice-network
 
   fitness-db:
-    image: mariadb:lts-noble
+    image: mariadb:10.11
     env_file:
       - .env
     restart: always
@@ -222,7 +222,7 @@ services:
       - microservice-network
 
   music-db:
-    image: mariadb:lts-noble
+    image: mariadb:10.11
     env_file:
       - .env
     restart: always

--- a/fitness-service/pom.xml
+++ b/fitness-service/pom.xml
@@ -54,6 +54,10 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/fitness-service/src/main/kotlin/com/michibaum/fitness_service/fitbit/subscriptions/FitbitNotification.kt
+++ b/fitness-service/src/main/kotlin/com/michibaum/fitness_service/fitbit/subscriptions/FitbitNotification.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 @Entity
 class FitbitNotification(
-    @Column(nullable = false, unique = false)
+    @Enumerated(EnumType.STRING)
     val collectionType: NotificationCollectionType,
 
     @Column(nullable = false, unique = false)

--- a/fitness-service/src/main/resources/application-dev.yml
+++ b/fitness-service/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ spring:
     url: jdbc:mariadb://localhost:3306/fitness-db
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/fitness-service/src/main/resources/application-prod.yml
+++ b/fitness-service/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
     url: jdbc:mariadb://fitness-db:3306/${DATABASE}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/fitness-service/src/main/resources/application.yml
+++ b/fitness-service/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
         disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
+  flyway:
+    enabled: true
+    baselineOnMigrate: true
+    validateOnMigrate: true
+    locations: classpath:db/migration
+    driver-class-name: org.mariadb.jdbc.Driver
 
 eureka:
   instance:

--- a/fitness-service/src/main/resources/db/migration/V1__initialschema.sql
+++ b/fitness-service/src/main/resources/db/migration/V1__initialschema.sql
@@ -1,0 +1,95 @@
+create table fitbit_subscription
+(
+    id uuid not null primary key,
+    user_id varchar(255) not null,
+    verification_code varchar(255) not null
+);
+
+create table fitbit_notification
+(
+    id uuid not null primary key,
+    collection_type enum('ACTIVITIES', 'BODY', 'FOODS', 'SLEEP', 'USER_REVOKED_ACCESS') null,
+    subscription_id uuid not null,
+    date varchar(255) not null,
+    owner_id varchar(255) not null,
+    owner_type varchar(255) not null,
+    user_id varchar(255) not null,
+    constraint FKpsfb0bejhn7dc8wcv83owosdt foreign key (subscription_id) references fitbit_subscription (id)
+);
+
+create table fitbitoauth_credentials
+(
+    id uuid not null primary key,
+    deactivated bit not null,
+    expires_in int not null,
+    created_date datetime(6) not null,
+    valid_until datetime(6) not null,
+    fitbit_user_id varchar(255) not null,
+    refresh_token varchar(255) not null,
+    scope varchar(255) not null,
+    user_id varchar(255) not null,
+    access_token text not null,
+    constraint UKcfsdfq1li2un48pctkiqgfos3 unique (access_token) using hash,
+    constraint UKseja4y645trnxbi76bw98883t unique (refresh_token)
+);
+
+create table fitbitoauth_data
+(
+    id uuid not null primary key,
+    code_challenge varchar(255) not null,
+    code_verifier varchar(255) not null,
+    state varchar(255) not null,
+    user_id varchar(255) not null,
+    constraint UK5a1wvv90ubjq9fp5aq8othp3 unique (code_verifier),
+    constraint UK8lohmmv4rcjqfgyvq9mqo45ia unique (code_challenge),
+    constraint UKgjukj60ntstleroy47u6joo3y unique (state)
+);
+
+create table profile
+(
+    id uuid not null primary key,
+    height double not null,
+    dtype varchar(31) not null,
+    age varchar(255) not null,
+    country varchar(255) not null,
+    full_name varchar(255) not null,
+    gender varchar(255) not null,
+    user_id varchar(255) not null
+);
+
+create table sleep
+(
+    id uuid not null primary key,
+    duration bigint not null,
+    end_time datetime(6) not null,
+    fitbit_id bigint not null,
+    start_time datetime(6) not null,
+    dtype varchar(31) not null,
+    user_id varchar(255) not null,
+    constraint UKeixguljyuktx0nrl2trwpv8s4 unique (fitbit_id)
+);
+
+create table sleep_stage
+(
+    id uuid not null primary key,
+    duration bigint not null,
+    end datetime(6) not null,
+    start datetime(6) not null,
+    sleep_id uuid null,
+    stage enum('ASLEEP', 'AWAKE', 'DEEP', 'LIGHT', 'REM', 'RESTLESS', 'UNKNOWN', 'WAKE') null,
+    constraint FK833rltsygocx618j999rn4wc3 foreign key (sleep_id) references sleep (id)
+);
+
+create table weight
+(
+    id uuid not null primary key,
+    bmi double not null,
+    fat_percentage int null,
+    weight double not null,
+    date datetime(6) not null,
+    fitbit_id bigint not null,
+    dtype varchar(31) not null,
+    user_id varchar(255) not null,
+    constraint UKpatau0u712jsiniwhrw7d9krm unique (fitbit_id)
+);
+

--- a/music-service/pom.xml
+++ b/music-service/pom.xml
@@ -54,6 +54,10 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/music-service/src/main/resources/application-dev.yml
+++ b/music-service/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ spring:
     url: jdbc:mariadb://localhost:3306/music-db
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/music-service/src/main/resources/application-prod.yml
+++ b/music-service/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
     url: jdbc:mariadb://music-db:3306/${DATABASE}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/music-service/src/main/resources/application.yml
+++ b/music-service/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
         disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
+  flyway:
+    enabled: true
+    baselineOnMigrate: true
+    validateOnMigrate: true
+    locations: classpath:db/migration
+    driver-class-name: org.mariadb.jdbc.Driver
 
 eureka:
   instance:

--- a/music-service/src/main/resources/db/migration/V1__initialschema.sql
+++ b/music-service/src/main/resources/db/migration/V1__initialschema.sql
@@ -1,0 +1,23 @@
+create table spotifyoauth_credentials
+(
+    id uuid not null primary key,
+    deactivated bit not null,
+    expires_in int not null,
+    created_date datetime(6) not null,
+    valid_until datetime(6) not null,
+    refresh_token varchar(255) not null,
+    scope varchar(255) not null,
+    user_id varchar(255) not null,
+    access_token text not null,
+    constraint UK5lca5huyguwx5xarhqnv6pm6o unique (refresh_token),
+    constraint UKr4v55p8xpmjmirddvqe44pm0q unique (access_token) using hash
+);
+
+create table spotifyoauth_data
+(
+    id uuid not null primary key,
+    state varchar(255) not null,
+    user_id varchar(255) not null,
+    constraint UKjd13gmmpei055slhjqok0m35t unique (state)
+);
+

--- a/usermanagement-service/pom.xml
+++ b/usermanagement-service/pom.xml
@@ -50,6 +50,10 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/usermanagement-service/src/main/resources/application-dev.yml
+++ b/usermanagement-service/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
     url: jdbc:mariadb://localhost:3306/usermanagement-db
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/usermanagement-service/src/main/resources/application-prod.yml
+++ b/usermanagement-service/src/main/resources/application-prod.yml
@@ -9,7 +9,7 @@ spring:
     url: jdbc:mariadb://usermanagement-db:3306/${DATABASE}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
   boot:
     admin:
       client:

--- a/usermanagement-service/src/main/resources/application.yml
+++ b/usermanagement-service/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
         disable-ssl-validation: true
   main:
     allow-bean-definition-overriding: true
+  flyway:
+    enabled: true
+    baselineOnMigrate: true
+    validateOnMigrate: true
+    locations: classpath:db/migration
+    driver-class-name: org.mariadb.jdbc.Driver
 
 eureka:
   instance:

--- a/usermanagement-service/src/main/resources/db/migration/V1__initialschema.sql
+++ b/usermanagement-service/src/main/resources/db/migration/V1__initialschema.sql
@@ -1,0 +1,35 @@
+create table permission
+(
+    permission varchar(255) not null primary key
+);
+
+INSERT INTO permission (permission) VALUES ('ADMIN_SERVICE');
+INSERT INTO permission (permission) VALUES ('AUTHENTICATION_SERVICE');
+INSERT INTO permission (permission) VALUES ('CHESS_SERVICE');
+INSERT INTO permission (permission) VALUES ('CHESS_SERVICE_ADMIN');
+INSERT INTO permission (permission) VALUES ('FITNESS_SERVICE');
+INSERT INTO permission (permission) VALUES ('MUSIC_SERVICE');
+INSERT INTO permission (permission) VALUES ('REGISTRY_SERVICE');
+INSERT INTO permission (permission) VALUES ('SERMANAGEMENT_SERVICE_EDIT_ALL_USER');
+INSERT INTO permission (permission) VALUES ('USERMANAGEMENT_SERVICE');
+INSERT INTO permission (permission) VALUES ('USERMANAGEMENT_SERVICE_EDIT_OWN_USER');
+
+create table user
+(
+    id uuid not null primary key,
+    email varchar(255) not null,
+    password varchar(255) not null,
+    username varchar(255) not null,
+    constraint UKob8kqyqqgmefl0aco34akdtpe unique (email),
+    constraint UKsb8bbouer5wak8vyiiy4pf2bx unique (username)
+);
+
+create table user_permission_mapping
+(
+    user_id uuid not null,
+    permission_id varchar(255) not null,
+    primary key (user_id, permission_id),
+    constraint FKfd079v5t2dt0yj8c6fodrf8ml foreign key (user_id) references user (id),
+    constraint FKihjegis3tdwmlnawifkuqkav9 foreign key (permission_id) references permission (permission)
+);
+


### PR DESCRIPTION
Introduced Flyway for database version control across all services, enabling schema validation and migration. Added initial schemas for `music-service`, `fitness-service`, `chess-service`, and `usermanagement-service` with specific tables for their respective domains. Updated configuration files to replace Hibernate's `ddl-auto` with Flyway for consistent schema management.