### PR TITLE
Update contributors-readme-action to v2.3.10

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -10,7 +10,7 @@ jobs:
     name: Automate contrib in readme
     steps:
       - name: Contribute List
-        uses: akhilmhdh/contributors-readme-action@v2.3.8
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
         with:
           collaborators: all
           commit_message: updated contributors in readme


### PR DESCRIPTION
---

**Description:**

- Update `contributors-readme-action` to version 2.3.10 for compatibility, bug fixes, and new features.
- The automation of updating the contributors list in the README file will be impacted by this change.