### PR TITLE
Bugfix: Add platform field to EventProvider test data

### DIFF
--- a/chess-service/src/test/kotlin/com/michibaum/chess_service/domain/EventProvider.kt
+++ b/chess-service/src/test/kotlin/com/michibaum/chess_service/domain/EventProvider.kt
@@ -15,7 +15,8 @@ class EventProvider {
                 dateFrom = LocalDate.of(2024, 11, 25),
                 dateTo = LocalDate.of(2024, 12, 13),
                 participants = participants,
-                internalComment = ""
+                internalComment = "",
+                platform = ChessPlatform.FIDE
             )
 
     }


### PR DESCRIPTION
This change updates the test data in EventProvider by including the `platform` field. It ensures alignment with the expected structure and improves test coverage for events using the `ChessPlatform` enum.