### PR TITLE
Bugfix jackson deserialize

### DIFF
--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/authentication/AuthenticationDto.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/authentication/AuthenticationDto.kt
@@ -1,3 +1,6 @@
 package com.michibaum.authentication_service.authentication
 
-class AuthenticationDto(val username: String, val password: String)
+data class AuthenticationDto(
+    val username: String,
+    val password: String
+)


### PR DESCRIPTION
15:24:18.396 [tomcat-handler-86] ERROR o.a.c.c.C.[.[.[.[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.springframework.http.converter.HttpMessageConversionException: Type definition error: [simple type, class com.michibaum.authentication_service.authentication.AuthenticationDto]] with root cause
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.michibaum.authentication_service.authentication.AuthenticationDto` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 2]