### PR TITLE
Set session management to stateless across all services.

### DIFF
--- a/admin-service/src/main/kotlin/com/michibaum/admin_service/security/SecurityConfiguration.kt
+++ b/admin-service/src/main/kotlin/com/michibaum/admin_service/security/SecurityConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -31,6 +32,8 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) }
             .build()
     }
 

--- a/authentication-library/src/main/kotlin/com/michibaum/authentication_library/security/ServletAuthenticationFilter.kt
+++ b/authentication-library/src/main/kotlin/com/michibaum/authentication_library/security/ServletAuthenticationFilter.kt
@@ -45,10 +45,7 @@ class ServletAuthenticationFilter(private val authenticationManager: Authenticat
                 filterChain.doFilter(request, response)
                 return
             }
-            val session = request.getSession(false)
-            if (session != null) {
-                request.changeSessionId()
-            }
+
             successfulAuthentication(request, response, filterChain, authenticationResult)
         } catch (ex: AuthenticationException) {
             unsuccessfulAuthentication(request, response, ex)

--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityConfiguration.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -40,6 +41,7 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .build()
     }
 

--- a/chess-service/src/main/kotlin/com/michibaum/chess_service/security/SecurityConfiguration.kt
+++ b/chess-service/src/main/kotlin/com/michibaum/chess_service/security/SecurityConfiguration.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -44,6 +45,8 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) }
             .build()
     }
 

--- a/fitness-service/src/main/kotlin/com/michibaum/fitness_service/security/SecurityConfiguration.kt
+++ b/fitness-service/src/main/kotlin/com/michibaum/fitness_service/security/SecurityConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -38,6 +39,8 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) }
             .build()
     }
 

--- a/music-service/src/main/kotlin/com/michibaum/music_service/security/SecurityConfiguration.kt
+++ b/music-service/src/main/kotlin/com/michibaum/music_service/security/SecurityConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -38,6 +39,8 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) }
             .build()
     }
 

--- a/registry-service/src/main/kotlin/com/michibaum/registry_service/security/SecurityConfiguration.kt
+++ b/registry-service/src/main/kotlin/com/michibaum/registry_service/security/SecurityConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -34,6 +35,8 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) }
             .build()
     }
 

--- a/usermanagement-service/src/main/kotlin/com/michibaum/usermanagement_service/security/SecurityConfiguration.kt
+++ b/usermanagement-service/src/main/kotlin/com/michibaum/usermanagement_service/security/SecurityConfiguration.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod.POST
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -34,6 +35,8 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) }
             .build()
     }
 

--- a/website-service/src/main/kotlin/com/michibaum/websiteservice/security/SecurityConfiguration.kt
+++ b/website-service/src/main/kotlin/com/michibaum/websiteservice/security/SecurityConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -34,6 +35,8 @@ class SecurityConfiguration {
             .formLogin { formLoginSpec -> formLoginSpec.disable() }
             .csrf { csrfSpec -> csrfSpec.disable() }
             .logout { logoutSpec -> logoutSpec.disable() }
+            .sessionManagement { sessionManagementSpec -> sessionManagementSpec.sessionCreationPolicy(
+                SessionCreationPolicy.STATELESS) }
             .build()
     }
 


### PR DESCRIPTION
Updated the security configuration of multiple services to enforce stateless session management with `SessionCreationPolicy.STATELESS`. Additionally, removed session handling logic in the authentication library to align with the stateless approach. This change enhances the security and scalability of the applications.