### PR TITLE
Update to Java 21 and clean up dependencies.

### DIFF
--- a/.run/All Project Tests.run.xml
+++ b/.run/All Project Tests.run.xml
@@ -11,7 +11,7 @@
       </ENTRIES>
     </extension>
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-23" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-21" />
     <option name="PACKAGE_NAME" value="com.michibaum" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/.run/All UT.run.xml
+++ b/.run/All UT.run.xml
@@ -11,7 +11,7 @@
       </ENTRIES>
     </extension>
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-23" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-21" />
     <option name="PACKAGE_NAME" value="com.michibaum" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -105,7 +105,7 @@
 						<version>3.4.4</version>
 						<configuration>
 							<from>
-								<image>eclipse-temurin:23-jre-alpine</image>
+								<image>eclipse-temurin:21-jre-alpine</image>
 								<auth>
 									<!--suppress UnresolvedMavenProperty -->
 									<username>${dockerHub.username}</username>

--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -149,7 +149,7 @@
                         <version>3.4.4</version>
                         <configuration>
                             <from>
-                                <image>eclipse-temurin:23-jre-alpine</image>
+                                <image>eclipse-temurin:21-jre-alpine</image>
                                 <auth>
                                     <!--suppress UnresolvedMavenProperty -->
                                     <username>${dockerHub.username}</username>

--- a/chess-service/pom.xml
+++ b/chess-service/pom.xml
@@ -159,7 +159,7 @@
                         <version>3.4.4</version>
                         <configuration>
                             <from>
-                                <image>eclipse-temurin:23-jre-alpine</image>
+                                <image>eclipse-temurin:21-jre-alpine</image>
                                 <auth>
                                     <!--suppress UnresolvedMavenProperty -->
                                     <username>${dockerHub.username}</username>

--- a/docs/Writerside/topics/Development.md
+++ b/docs/Writerside/topics/Development.md
@@ -1,7 +1,7 @@
 # Development
 
 Requirements:
-- Java 23 installed
+- Java 21 installed
 - Npm installed (lts is best)
 - [Update hosts file](#update-hosts-file)
 - Local dev database

--- a/fitness-service/pom.xml
+++ b/fitness-service/pom.xml
@@ -136,7 +136,7 @@
                         <version>3.4.4</version>
                         <configuration>
                             <from>
-                                <image>eclipse-temurin:23-jre-alpine</image>
+                                <image>eclipse-temurin:21-jre-alpine</image>
                                 <auth>
                                     <!--suppress UnresolvedMavenProperty -->
                                     <username>${dockerHub.username}</username>

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -107,7 +107,7 @@
 						<version>3.4.4</version>
 						<configuration>
 							<from>
-								<image>eclipse-temurin:23-jre-alpine</image>
+								<image>eclipse-temurin:21-jre-alpine</image>
 								<auth>
 									<!--suppress UnresolvedMavenProperty -->
 									<username>${dockerHub.username}</username>

--- a/music-service/pom.xml
+++ b/music-service/pom.xml
@@ -136,7 +136,7 @@
                         <version>3.4.4</version>
                         <configuration>
                             <from>
-                                <image>eclipse-temurin:23-jre-alpine</image>
+                                <image>eclipse-temurin:21-jre-alpine</image>
                                 <auth>
                                     <!--suppress UnresolvedMavenProperty -->
                                     <username>${dockerHub.username}</username>

--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,17 @@
         <spring-boot-admin.version>3.4.1</spring-boot-admin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <java.version>21</java.version>
 
         <!--
         https://stackoverflow.com/a/77179226/10258204
         https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
         -->
         <kotlin.version>2.1.0</kotlin.version>
+        <kotlin.compiler.languageVersion>2.1</kotlin.compiler.languageVersion>
+        <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
 
         <!--
         https://mockk.io/
@@ -255,13 +257,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>3.1.1</version> <!-- TODO check if version 3.1.1 works else revert to 3.0.1 -->
-                <configuration>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <extensions>true</extensions>
@@ -290,6 +285,11 @@
                         <version>${kotlin.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.1.1</version> <!-- TODO check if version 3.1.1 works else revert to 3.0.1 -->
             </plugin>
 
 		</plugins>

--- a/registry-service/pom.xml
+++ b/registry-service/pom.xml
@@ -102,7 +102,7 @@
                         <version>3.4.4</version>
                         <configuration>
                             <from>
-                                <image>eclipse-temurin:23-jre-alpine</image>
+                                <image>eclipse-temurin:21-jre-alpine</image>
                                 <auth>
                                     <!--suppress UnresolvedMavenProperty -->
                                     <username>${dockerHub.username}</username>

--- a/spring-boot-starter-discord/src/main/kotlin/com/michibaum/discord/api/DiscordClientImpl.kt
+++ b/spring-boot-starter-discord/src/main/kotlin/com/michibaum/discord/api/DiscordClientImpl.kt
@@ -1,6 +1,5 @@
 package com.michibaum.discord.api
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.michibaum.discord.api.dtos.*
 import com.michibaum.discord.config.DiscordProperties
 import org.springframework.core.ParameterizedTypeReference
@@ -16,11 +15,9 @@ import org.springframework.web.client.bodyWithType
  * specific to the Discord API v10.
  *
  * @property properties Configuration properties containing the bot token and guild ID.
- * @property objectMapper ObjectMapper instance for JSON serialization and deserialization.
  */
 open class DiscordClientImpl(
-    private val properties: DiscordProperties,
-    private val objectMapper: ObjectMapper
+    private val properties: DiscordProperties
 ): DiscordClient {
 
     /**

--- a/spring-boot-starter-discord/src/main/kotlin/com/michibaum/discord/config/DiscordAutoConfiguration.kt
+++ b/spring-boot-starter-discord/src/main/kotlin/com/michibaum/discord/config/DiscordAutoConfiguration.kt
@@ -1,6 +1,5 @@
 package com.michibaum.discord.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.michibaum.discord.api.DiscordClient
 import com.michibaum.discord.api.DiscordClientImpl
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -21,30 +20,15 @@ import org.springframework.context.annotation.Bean
 class DiscordAutoConfiguration {
 
     /**
-     * Provides an `ObjectMapper` bean for JSON processing.
-     *
-     * This method returns a singleton instance of `ObjectMapper` which is used for JSON serialization and
-     * deserialization throughout the application. The bean is only provided if an `ObjectMapper` bean
-     * is not already present in the application context.
-     *
-     * @return An instance of `ObjectMapper`.
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    fun objectMapper() = ObjectMapper()
-
-    /**
      * Creates a `DiscordClient` bean if one is not already present in the application context.
      *
      * @param properties Configuration properties for the Discord integration.
-     * @param objectMapper The ObjectMapper instance for JSON processing.
      * @return An instance of `DiscordClient`.
      */
     @Bean
-    @ConditionalOnBean(value = [ObjectMapper::class])
     @ConditionalOnMissingBean
-    fun discordClient(properties: DiscordProperties, objectMapper: ObjectMapper): DiscordClient {
-        return DiscordClientImpl(properties, objectMapper)
+    fun discordClient(properties: DiscordProperties): DiscordClient {
+        return DiscordClientImpl(properties)
     }
 
 }

--- a/usermanagement-service/pom.xml
+++ b/usermanagement-service/pom.xml
@@ -146,7 +146,7 @@
                         <version>3.4.4</version>
                         <configuration>
                             <from>
-                                <image>eclipse-temurin:23-jre-alpine</image>
+                                <image>eclipse-temurin:21-jre-alpine</image>
                                 <auth>
                                     <!--suppress UnresolvedMavenProperty -->
                                     <username>${dockerHub.username}</username>

--- a/website-service/pom.xml
+++ b/website-service/pom.xml
@@ -95,7 +95,7 @@
                         <version>3.4.4</version>
                         <configuration>
                             <from>
-                                <image>eclipse-temurin:23-jre-alpine</image>
+                                <image>eclipse-temurin:21-jre-alpine</image>
                                 <auth>
                                     <!--suppress UnresolvedMavenProperty -->
                                     <username>${dockerHub.username}</username>


### PR DESCRIPTION
Switch all services and configurations to use Java 21, replacing Java 23 references. Remove unused Jackson ObjectMapper dependency and associated logic from Discord client. Adjust Maven settings to ensure compatibility with the updated Java version.