### PR TITLE
Introduce PublicEndpoint for dynamic public endpoint resolution

### DIFF
--- a/admin-service/src/main/kotlin/com/michibaum/admin_service/security/SecurityBeansConfiguration.kt
+++ b/admin-service/src/main/kotlin/com/michibaum/admin_service/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,8 @@
 package com.michibaum.admin_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -18,6 +20,10 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.admin_service")
 
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =

--- a/admin-service/src/main/kotlin/com/michibaum/admin_service/security/SecurityConfiguration.kt
+++ b/admin-service/src/main/kotlin/com/michibaum/admin_service/security/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package com.michibaum.admin_service.security
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.permission_library.Permissions
 import org.springframework.context.annotation.Bean
@@ -20,12 +21,15 @@ class SecurityConfiguration {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
-        authenticationFilter: ServletAuthenticationFilter
+        authenticationFilter: ServletAuthenticationFilter,
+        publicEndpointResolver: PublicEndpointResolver
     ): SecurityFilterChain {
+        val publicEndpoints = publicEndpointResolver.run()
         return http
-            .authorizeHttpRequests {
-                it.anyRequest()
-                    .hasAnyAuthority(Permissions.ADMIN_SERVICE.name)
+            .authorizeHttpRequests { authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(*publicEndpoints.map { it.requestMatcher}.toTypedArray()).permitAll()
+                    .anyRequest().hasAnyAuthority(Permissions.ADMIN_SERVICE.name)
             }
             .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .httpBasic { httpBasicSpec -> httpBasicSpec.disable() }

--- a/authentication-library/src/main/kotlin/com/michibaum/authentication_library/public_endpoints/PublicEndpoint.kt
+++ b/authentication-library/src/main/kotlin/com/michibaum/authentication_library/public_endpoints/PublicEndpoint.kt
@@ -1,0 +1,7 @@
+package com.michibaum.authentication_library.public_endpoints
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PublicEndpoint(
+
+)

--- a/authentication-library/src/main/kotlin/com/michibaum/authentication_library/public_endpoints/PublicEndpointDetails.kt
+++ b/authentication-library/src/main/kotlin/com/michibaum/authentication_library/public_endpoints/PublicEndpointDetails.kt
@@ -1,0 +1,25 @@
+package com.michibaum.authentication_library.public_endpoints
+
+import org.springframework.http.HttpMethod
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.RequestMatcher
+import org.springframework.web.bind.annotation.RequestMethod
+
+class PublicEndpointDetails(
+    val rawPath: String,
+    requestMethod: RequestMethod
+) {
+
+    val antPath: String = createAntPath()
+    val httpMethod: HttpMethod = HttpMethod.valueOf(requestMethod.name)
+    val requestMatcher: RequestMatcher = createRequestMatcher()
+
+    private fun createAntPath(): String {
+        return rawPath.replace("\\{.*}".toRegex(), "*")
+    }
+
+    private fun createRequestMatcher(): RequestMatcher {
+        return AntPathRequestMatcher.antMatcher(httpMethod, antPath)
+    }
+
+}

--- a/authentication-library/src/main/kotlin/com/michibaum/authentication_library/public_endpoints/PublicEndpointResolver.kt
+++ b/authentication-library/src/main/kotlin/com/michibaum/authentication_library/public_endpoints/PublicEndpointResolver.kt
@@ -1,0 +1,125 @@
+package com.michibaum.authentication_library.public_endpoints
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.web.bind.annotation.*
+import java.lang.reflect.Method
+
+
+class PublicEndpointResolver(
+    private val publicAnnotation: Class<out Annotation>,
+    private vararg val packageName: String
+) { // TODO take into account that @RestController can have @RequestMapping
+
+    private val logger: Logger = LoggerFactory.getLogger(PublicEndpointResolver::class.java)
+
+    fun run(): List<PublicEndpointDetails> {
+        val mappings = getAllRestController()
+            .map { getMethodsAnnotatedWith(it) }
+            .map { getMappingValue(it) }
+            .flatten()
+
+        logger.info("Found ${mappings.size} public endpoints")
+        for (mapping in mappings) {
+            logger.info("Mapping: ${mapping.httpMethod} '${mapping.rawPath}' converted to antPath: '${mapping.antPath}'")
+        }
+        return mappings
+    }
+
+
+    private fun getMethodsAnnotatedWith(type: Class<*>): List<Method> {
+        logger.debug("Searching for methods annotated with ${publicAnnotation.name} in class: ${type.name}")
+        val methods: Array<Method> = type.methods
+        logger.debug("Found ${methods.size} methods")
+        val annotatedMethods: MutableList<Method> = ArrayList(methods.size)
+        for (method in methods) {
+            if (method.isAnnotationPresent(publicAnnotation)) {
+                annotatedMethods.add(method)
+            }
+        }
+        logger.debug("Found ${annotatedMethods.size} annotated methods")
+        return annotatedMethods
+    }
+
+    private fun getMappingValue(methods: List<Method>): List<PublicEndpointDetails> {
+        return methods.map { getMappingValue(it) }
+            .flatten()
+            .toList()
+    }
+
+    private fun getMappingValue(method: Method): List<PublicEndpointDetails> {
+        logger.debug("Searching for mapping annotation on method: ${method.name}")
+
+        val mappings = ArrayList<PublicEndpointDetails>()
+
+        getEndpointsFromRequestMapping(method).also {
+            mappings.addAll(it)
+        }
+
+        if(method.isAnnotationPresent(GetMapping::class.java)){
+            val paths = method.getAnnotation(GetMapping::class.java).value
+            val result = paths.map { PublicEndpointDetails(it, RequestMethod.GET) }
+            mappings.addAll(result)
+        }
+
+        if(method.isAnnotationPresent(PostMapping::class.java)){
+            val paths = method.getAnnotation(PostMapping::class.java).value
+            val result = paths.map { PublicEndpointDetails(it, RequestMethod.POST) }
+            mappings.addAll(result)
+        }
+
+        if(method.isAnnotationPresent(PutMapping::class.java)){
+            val paths = method.getAnnotation(PutMapping::class.java).value
+            val result = paths.map { PublicEndpointDetails(it, RequestMethod.PUT) }
+            mappings.addAll(result)
+        }
+
+        if(method.isAnnotationPresent(PatchMapping::class.java)){
+            val paths = method.getAnnotation(PatchMapping::class.java).value
+            val result = paths.map { PublicEndpointDetails(it, RequestMethod.PATCH) }
+            mappings.addAll(result)
+        }
+
+        if (method.isAnnotationPresent(DeleteMapping::class.java)) {
+            val paths = method.getAnnotation(DeleteMapping::class.java).value
+            val result = paths.map { PublicEndpointDetails(it, RequestMethod.DELETE) }
+            mappings.addAll(result)
+        }
+
+        logger.debug("Found mapping: $mappings")
+        return mappings
+    }
+
+    private fun getEndpointsFromRequestMapping(
+        method: Method,
+    ): List<PublicEndpointDetails> {
+        if (method.isAnnotationPresent(RequestMapping::class.java)) {
+            val paths = method.getAnnotation(RequestMapping::class.java).value
+            val methods = method.getAnnotation(RequestMapping::class.java).method
+            val result = paths.map { path ->
+                methods.map { method ->
+                    PublicEndpointDetails(path, method)
+                }
+            }.flatten()
+            return result
+        }
+        return emptyList()
+    }
+
+    private fun getAllRestController(): List<Class<*>> {
+        logger.debug("Searching for all RestController in packages: ${packageName.joinToString(", ")}")
+        val scanner = ClassPathScanningCandidateComponentProvider(false)
+        scanner.addIncludeFilter(AnnotationTypeFilter(RestController::class.java))
+        val beanDefinitions = packageName.map { scanner.findCandidateComponents(it) }
+            .flatten()
+            .filterNotNull()
+
+        logger.debug("Found ${beanDefinitions.size} RestController")
+        val classes = beanDefinitions.map { Class.forName(it.beanClassName) }.filterNotNull().toList()
+        logger.debug("Resolved ${classes.size} classes of RestController")
+        return classes
+    }
+
+}

--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/authentication/AuthenticationController.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/authentication/AuthenticationController.kt
@@ -2,6 +2,7 @@ package com.michibaum.authentication_service.authentication
 
 import com.michibaum.authentication_library.AuthenticationEndpoints
 import com.michibaum.authentication_library.PublicKeyDto
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
 import com.michibaum.usermanagement_library.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
@@ -20,6 +21,7 @@ class AuthenticationController (
     @Lazy
     lateinit var usermanagementClient: UsermanagementClient
 
+    @PublicEndpoint
     @PostMapping(value = ["/api/authenticate"])
     fun authenticate(@RequestBody authenticationDto: AuthenticationDto): ResponseEntity<AuthenticationResponse> {
         val loginDto = LoginDto(authenticationDto.username, authenticationDto.password)
@@ -36,6 +38,7 @@ class AuthenticationController (
         return ResponseEntity.ok().body(responseBody)
     }
 
+    @PublicEndpoint
     @PostMapping(value = ["/api/register"])
     fun register(@RequestBody registerDto: RegisterDto): ResponseEntity<RegisterResponse> {
         val createUserDto = CreateUserDto(registerDto.username, registerDto.email, registerDto.password)

--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityBeansConfiguration.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityBeansConfiguration.kt
@@ -2,6 +2,8 @@ package com.michibaum.authentication_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
 import com.michibaum.authentication_library.PublicKeyDto
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -19,6 +21,10 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.authentication_service")
+
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =
         AdminServiceCredentials()

--- a/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityConfiguration.kt
+++ b/authentication-service/src/main/kotlin/com/michibaum/authentication_service/security/SecurityConfiguration.kt
@@ -1,9 +1,11 @@
 package com.michibaum.authentication_service.security
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.permission_library.Permissions
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod.GET
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -20,16 +22,15 @@ class SecurityConfiguration {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
-        authenticationFilter: ServletAuthenticationFilter
+        authenticationFilter: ServletAuthenticationFilter,
+        publicEndpointResolver: PublicEndpointResolver
     ): SecurityFilterChain {
+        val publicEndpoints = publicEndpointResolver.run()
         return http
-            .authorizeHttpRequests {
-                it
-                    .requestMatchers(
-                        "/api/authenticate",
-                        "/api/getAuthDetails",
-                        "/api/register"
-                    ).permitAll()
+            .authorizeHttpRequests { authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(*publicEndpoints.map { it.requestMatcher}.toTypedArray()).permitAll()
+                    .requestMatchers(GET, "/api/getAuthDetails").permitAll()
                     .requestMatchers(
                         "/actuator",
                         "/actuator/**"

--- a/chess-service/src/main/kotlin/com/michibaum/chess_service/app/event/EventController.kt
+++ b/chess-service/src/main/kotlin/com/michibaum/chess_service/app/event/EventController.kt
@@ -1,5 +1,6 @@
 package com.michibaum.chess_service.app.event
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
 import com.michibaum.chess_service.app.game.GameConverter
 import com.michibaum.chess_service.app.game.GameDto
 import com.michibaum.chess_service.app.game.GameService
@@ -24,6 +25,7 @@ class EventController(
     private val gameConverter: GameConverter
 ) {
 
+    @PublicEndpoint
     @GetMapping("/api/events")
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.REPEATABLE_READ)
     fun getAllEvents(): List<EventDto> =
@@ -46,6 +48,7 @@ class EventController(
             .map { eventConverter.toDto(it) }
     }
 
+    @PublicEndpoint
     @GetMapping("/api/events/{id}")
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.REPEATABLE_READ)
     fun getEvent(@PathVariable id: String): ResponseEntity<EventDto>{
@@ -62,6 +65,7 @@ class EventController(
         }
     }
 
+    @PublicEndpoint
     @GetMapping("/api/events/{id}/participants")
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.REPEATABLE_READ)
     fun getEventParticipants(@PathVariable id: String): ResponseEntity<List<PersonDto>> {
@@ -79,6 +83,7 @@ class EventController(
         }
     }
 
+    @PublicEndpoint
     @GetMapping("/api/events/{id}/games")
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.REPEATABLE_READ)
     fun getEventGames(@PathVariable id: String): ResponseEntity<List<GameDto>> {

--- a/chess-service/src/main/kotlin/com/michibaum/chess_service/app/eventcategory/EventCategoryController.kt
+++ b/chess-service/src/main/kotlin/com/michibaum/chess_service/app/eventcategory/EventCategoryController.kt
@@ -1,6 +1,6 @@
 package com.michibaum.chess_service.app.eventcategory
 
-import com.michibaum.authentication_library.security.jwt.JwtAuthentication
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
 import com.michibaum.chess_service.app.event.EventConverter
 import com.michibaum.chess_service.app.event.EventService
 import jakarta.validation.Valid
@@ -20,6 +20,7 @@ class EventCategoryController(
     private val eventConverter: EventConverter
 ) {
 
+    @PublicEndpoint
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.REPEATABLE_READ)
     @GetMapping("/api/event-categories")
     fun getEventCategories(): ResponseEntity<List<EventCategoryDto>> {
@@ -28,6 +29,7 @@ class EventCategoryController(
         return ResponseEntity.ok().body(categoryDtos)
     }
 
+    @PublicEndpoint
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.REPEATABLE_READ)
     @GetMapping("/api/event-categories/with-events")
     fun getEventCategoriesWithEvents(): ResponseEntity<List<EventCategoryWithEventDto>> {

--- a/chess-service/src/main/kotlin/com/michibaum/chess_service/app/person/PersonController.kt
+++ b/chess-service/src/main/kotlin/com/michibaum/chess_service/app/person/PersonController.kt
@@ -1,7 +1,5 @@
 package com.michibaum.chess_service.app.person
 
-import com.michibaum.chess_service.apis.fide.FideApiService
-import com.michibaum.chess_service.app.event.EventService
 import jakarta.validation.Valid
 import org.springframework.core.io.buffer.DataBuffer
 import org.springframework.core.io.buffer.DataBufferUtils
@@ -21,9 +19,9 @@ import java.util.*
 @RestController
 class PersonController(
     private val personService: PersonService,
-    private val personConverter: PersonConverter,
-    private val fideApiService: FideApiService,
-    private val eventService: EventService,
+    private val personConverter: PersonConverter
+//    private val fideApiService: FideApiService,
+//    private val eventService: EventService,
 ) {
 
     @Transactional(propagation = Propagation.REQUIRED, readOnly = true, isolation = Isolation.REPEATABLE_READ)

--- a/chess-service/src/main/kotlin/com/michibaum/chess_service/security/SecurityBeansConfiguration.kt
+++ b/chess-service/src/main/kotlin/com/michibaum/chess_service/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,8 @@
 package com.michibaum.chess_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -18,6 +20,10 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.chess_service")
 
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =

--- a/chess-service/src/main/kotlin/com/michibaum/chess_service/security/SecurityConfiguration.kt
+++ b/chess-service/src/main/kotlin/com/michibaum/chess_service/security/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package com.michibaum.chess_service.security
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.permission_library.Permissions
 import org.springframework.context.annotation.Bean
@@ -21,19 +22,14 @@ class SecurityConfiguration {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
-        authenticationFilter: ServletAuthenticationFilter
+        authenticationFilter: ServletAuthenticationFilter,
+        publicEndpointResolver: PublicEndpointResolver
     ): SecurityFilterChain {
+        val publicEndpoints = publicEndpointResolver.run()
         return http
-            .authorizeHttpRequests {
-                it
-                    .requestMatchers(
-                        HttpMethod.GET,"/api/events",
-                        "/api/events/*",
-                        "/api/events/*/participants",
-                        "/api/events/*/games",
-                        "/api/event-categories",
-                        "/api/event-categories/with-events"
-                    ).permitAll()
+            .authorizeHttpRequests { authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(*publicEndpoints.map { it.requestMatcher}.toTypedArray()).permitAll()
                     .requestMatchers(
                         "/actuator",
                         "/actuator/**"

--- a/fitness-service/src/main/kotlin/com/michibaum/fitness_service/fitbit/oauth/FitbitOAuthController.kt
+++ b/fitness-service/src/main/kotlin/com/michibaum/fitness_service/fitbit/oauth/FitbitOAuthController.kt
@@ -1,5 +1,6 @@
 package com.michibaum.fitness_service.fitbit.oauth
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
 import com.michibaum.authentication_library.security.jwt.JwtAuthentication
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -59,6 +60,7 @@ class FitbitOAuthController(
 
     }
 
+    @PublicEndpoint
     @GetMapping("/api/fitbit/auth")
     fun authorizationCode(@RequestParam code: String, @RequestParam state: String){
         val oAuthData = fitbitOAuthService.findByState(state) ?: throw Exception("No oAuthData found by state $state")

--- a/fitness-service/src/main/kotlin/com/michibaum/fitness_service/security/SecurityBeansConfiguration.kt
+++ b/fitness-service/src/main/kotlin/com/michibaum/fitness_service/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,8 @@
 package com.michibaum.fitness_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -18,6 +20,10 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.fitness_service")
 
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =

--- a/fitness-service/src/main/kotlin/com/michibaum/fitness_service/security/SecurityConfiguration.kt
+++ b/fitness-service/src/main/kotlin/com/michibaum/fitness_service/security/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package com.michibaum.fitness_service.security
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.permission_library.Permissions
 import org.springframework.context.annotation.Bean
@@ -20,14 +21,14 @@ class SecurityConfiguration {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
-        authenticationFilter: ServletAuthenticationFilter
+        authenticationFilter: ServletAuthenticationFilter,
+        publicEndpointResolver: PublicEndpointResolver
     ): SecurityFilterChain {
+        val publicEndpoints = publicEndpointResolver.run()
         return http
-            .authorizeHttpRequests {
-                it
-                    .requestMatchers(
-                        "/api/fitbit/auth",
-                    ).permitAll()
+            .authorizeHttpRequests { authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(*publicEndpoints.map { it.requestMatcher}.toTypedArray()).permitAll()
                     .requestMatchers(
                         "/actuator",
                         "/actuator/**"

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
     name: gateway-service
   cloud:
     gateway:
-      routes:
+      routes: # TODO permission to Authentication
         - id: admin
           uri: lb://admin-service
           predicates:

--- a/music-service/src/main/kotlin/com/michibaum/music_service/security/SecurityBeansConfiguration.kt
+++ b/music-service/src/main/kotlin/com/michibaum/music_service/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,8 @@
 package com.michibaum.music_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -18,6 +20,10 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.music_service")
 
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =

--- a/music-service/src/main/kotlin/com/michibaum/music_service/security/SecurityConfiguration.kt
+++ b/music-service/src/main/kotlin/com/michibaum/music_service/security/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package com.michibaum.music_service.security
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.permission_library.Permissions
 import org.springframework.context.annotation.Bean
@@ -20,14 +21,14 @@ class SecurityConfiguration {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
-        authenticationFilter: ServletAuthenticationFilter
+        authenticationFilter: ServletAuthenticationFilter,
+        publicEndpointResolver: PublicEndpointResolver
     ): SecurityFilterChain {
+        val publicEndpoints = publicEndpointResolver.run()
         return http
-            .authorizeHttpRequests {
-                it
-                    .requestMatchers(
-                        "/api/spotify/auth",
-                    ).permitAll()
+            .authorizeHttpRequests { authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(*publicEndpoints.map { it.requestMatcher}.toTypedArray()).permitAll()
                     .requestMatchers(
                         "/actuator",
                         "/actuator/**"

--- a/music-service/src/main/kotlin/com/michibaum/music_service/spotify/oauth/SpotifyOAuthController.kt
+++ b/music-service/src/main/kotlin/com/michibaum/music_service/spotify/oauth/SpotifyOAuthController.kt
@@ -1,5 +1,6 @@
 package com.michibaum.music_service.spotify.oauth
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
 import com.michibaum.authentication_library.security.jwt.JwtAuthentication
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -60,6 +61,7 @@ class SpotifyOAuthController(
         )
     }
 
+    @PublicEndpoint
     @GetMapping("/api/spotify/auth")
     fun authorizationCode(@RequestParam code: String, @RequestParam state: String) {
         val oAuthData = spotifyOAuthService.findByState(state) ?: throw Exception("No oAuthData found by state $state")

--- a/registry-service/src/main/kotlin/com/michibaum/registry_service/security/SecurityBeansConfiguration.kt
+++ b/registry-service/src/main/kotlin/com/michibaum/registry_service/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,8 @@
 package com.michibaum.registry_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -18,6 +20,10 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.registry_service")
 
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =

--- a/registry-service/src/main/kotlin/com/michibaum/registry_service/security/SecurityConfiguration.kt
+++ b/registry-service/src/main/kotlin/com/michibaum/registry_service/security/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package com.michibaum.registry_service.security
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.permission_library.Permissions
 import org.springframework.context.annotation.Bean
@@ -20,15 +21,19 @@ class SecurityConfiguration {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
-        authenticationFilter: ServletAuthenticationFilter
+        authenticationFilter: ServletAuthenticationFilter,
+        publicEndpointResolver: PublicEndpointResolver
     ): SecurityFilterChain {
+        val publicEndpoints = publicEndpointResolver.run()
         return http
-            .authorizeHttpRequests {
-                it.requestMatchers(
-                    "/actuator",
-                    "/actuator/**"
-                ).hasAnyAuthority(Permissions.ADMIN_SERVICE.name)
-                .anyRequest().permitAll()
+            .authorizeHttpRequests { authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(*publicEndpoints.map { it.requestMatcher}.toTypedArray()).permitAll()
+                    .requestMatchers(
+                        "/actuator",
+                        "/actuator/**"
+                    ).hasAnyAuthority(Permissions.ADMIN_SERVICE.name)
+                    .anyRequest().permitAll()
             }
             .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .httpBasic { httpBasicSpec -> httpBasicSpec.disable() }

--- a/usermanagement-service/src/main/kotlin/com/michibaum/usermanagement_service/security/SecurityBeansConfiguration.kt
+++ b/usermanagement-service/src/main/kotlin/com/michibaum/usermanagement_service/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,8 @@
 package com.michibaum.usermanagement_service.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -18,6 +20,11 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.usermanagement_service")
+
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =
         AdminServiceCredentials()

--- a/usermanagement-service/src/main/kotlin/com/michibaum/usermanagement_service/security/SecurityConfiguration.kt
+++ b/usermanagement-service/src/main/kotlin/com/michibaum/usermanagement_service/security/SecurityConfiguration.kt
@@ -1,5 +1,6 @@
 package com.michibaum.usermanagement_service.security
 
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.permission_library.Permissions
 import org.springframework.context.annotation.Bean
@@ -21,11 +22,14 @@ class SecurityConfiguration {
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
-        authenticationFilter: ServletAuthenticationFilter
+        authenticationFilter: ServletAuthenticationFilter,
+        publicEndpointResolver: PublicEndpointResolver
     ): SecurityFilterChain {
+        val publicEndpoints = publicEndpointResolver.run()
         return http
-            .authorizeHttpRequests {
-                it
+            .authorizeHttpRequests { authorizeHttpRequests ->
+                authorizeHttpRequests
+                    .requestMatchers(*publicEndpoints.map { it.requestMatcher}.toTypedArray()).permitAll()
                     .requestMatchers(POST,"/api/checkUserDetails", "/api/users").permitAll()
                     .requestMatchers("/actuator", "/actuator/**").hasAnyAuthority(Permissions.ADMIN_SERVICE.name)
                     .anyRequest().authenticated()

--- a/website-service/src/main/kotlin/com/michibaum/websiteservice/security/SecurityBeansConfiguration.kt
+++ b/website-service/src/main/kotlin/com/michibaum/websiteservice/security/SecurityBeansConfiguration.kt
@@ -1,6 +1,8 @@
 package com.michibaum.websiteservice.security
 
 import com.michibaum.authentication_library.AuthenticationClient
+import com.michibaum.authentication_library.public_endpoints.PublicEndpoint
+import com.michibaum.authentication_library.public_endpoints.PublicEndpointResolver
 import com.michibaum.authentication_library.security.ServletAuthenticationFilter
 import com.michibaum.authentication_library.security.ServletDelegateAuthenticationManager
 import com.michibaum.authentication_library.security.SpecificAuthenticationManager
@@ -19,6 +21,10 @@ import org.springframework.security.web.authentication.AuthenticationConverter
 
 @Configuration
 class SecurityBeansConfiguration {
+
+    @Bean
+    fun publicEndpointResolver(): PublicEndpointResolver =
+        PublicEndpointResolver(PublicEndpoint::class.java, "com.michibaum.websiteservice")
 
     @Bean
     fun adminServiceCredentials(): AdminServiceCredentials =


### PR DESCRIPTION
Added `PublicEndpoint` annotation and `PublicEndpointResolver` to centralize the management of public endpoints across services. Updated each service to use `PublicEndpointResolver` for dynamic endpoint configuration, replacing hardcoded endpoint declarations. This enhances maintainability and reduces redundancy in access control configurations.