### PR TITLE
BUGFIX: Disable HTTP/2 in production configuration

### DIFF
--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -3,8 +3,11 @@ server:
   ssl:
     enabled: true
     bundle: server
+#    TODO HTTP/2 behaves slightly differently from HTTP/1.1 in terms of how headers and paths are normalized and passed through. For example:
+#    - HTTP/2 employs multiplexing and avoids redundant headers like `Host`, which might behave differently with Spring Gateway.
+#    - Your predicates like `host("admin.michibaum.*")` or others may not match properly under HTTP/2.
   http2:
-    enabled: true
+    enabled: false
 
 spring:
   ssl:


### PR DESCRIPTION
HTTP/2 support was disabled due to potential issues with Spring Gateway header and path normalization. This ensures compatibility with existing predicates and avoids unexpected behavior in routing.