### PR TITLE
Enable HTTP/2 support across all services. Dev env works.

### DIFF
--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/authentication-service/src/main/resources/application.yml
+++ b/authentication-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/chess-service/src/main/resources/application.yml
+++ b/chess-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/fitness-service/src/main/resources/application.yml
+++ b/fitness-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -3,11 +3,6 @@ server:
   ssl:
     enabled: true
     bundle: server
-#    TODO HTTP/2 behaves slightly differently from HTTP/1.1 in terms of how headers and paths are normalized and passed through. For example:
-#    - HTTP/2 employs multiplexing and avoids redundant headers like `Host`, which might behave differently with Spring Gateway.
-#    - Your predicates like `host("admin.michibaum.*")` or others may not match properly under HTTP/2.
-  http2:
-    enabled: false
 
 spring:
   ssl:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/music-service/src/main/resources/application.yml
+++ b/music-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/registry-service/src/main/resources/application.yml
+++ b/registry-service/src/main/resources/application.yml
@@ -7,6 +7,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/usermanagement-service/src/main/resources/application.yml
+++ b/usermanagement-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:

--- a/website-service/src/main/resources/application.yml
+++ b/website-service/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
+  http2:
+    enabled: true
 
 spring:
   threads:


### PR DESCRIPTION
HTTP/2 is now enabled in the configuration files of all services to improve performance through multiplexing and more efficient resource utilization. Additionally, redundant comments regarding HTTP/2 behavior in the Gateway service's production configuration have been removed.