### PR TITLE
Disable HTTP/2 protocol configuration temporarily.

### DIFF
--- a/admin-service/src/main/resources/application.yml
+++ b/admin-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/authentication-service/src/main/resources/application.yml
+++ b/authentication-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/chess-service/src/main/resources/application.yml
+++ b/chess-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/fitness-service/src/main/resources/application.yml
+++ b/fitness-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/music-service/src/main/resources/application.yml
+++ b/music-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/registry-service/src/main/resources/application.yml
+++ b/registry-service/src/main/resources/application.yml
@@ -7,8 +7,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/usermanagement-service/src/main/resources/application.yml
+++ b/usermanagement-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:

--- a/website-service/src/main/resources/application.yml
+++ b/website-service/src/main/resources/application.yml
@@ -6,8 +6,9 @@ server:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
     min-response-size: 1024
-  http2:
-    enabled: true
+#  TODO Issue: https://github.com/MichiBaum/Microservices/issues/170
+#  http2:
+#    enabled: true
 
 spring:
   threads:


### PR DESCRIPTION
Commented out HTTP/2 settings in all services due to issues outlined in GitHub Issue #170. This is a temporary change to prevent potential disruptions until the issue is resolved.