### PR TITLE
Fix vulnerable versions

### DIFF
--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -15,6 +15,7 @@
 	<properties>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
+		<xstream.version>1.4.21</xstream.version>
 	</properties>
 
 	<dependencies>
@@ -46,6 +47,17 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
+		<dependency>
+			<!--
+			TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+			 https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+			 https://github.com/Netflix/eureka/pull/1572
+			 -->
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>1.4.21</version>
+		</dependency>
+
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -49,6 +49,15 @@
 		</dependency>
 		<dependency>
 			<!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.14</version>
+		</dependency>
+		<dependency>
+			<!--
 			TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
 			 https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
 			 https://github.com/Netflix/eureka/pull/1572

--- a/authentication-library/pom.xml
+++ b/authentication-library/pom.xml
@@ -24,6 +24,15 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47554 commons-io:2.11.0 in spring-cloud-starter-openfeign with 2.14.0
+             https://www.mend.io/vulnerability-database/CVE-2024-47554?utm_source=JetBrains
+             -->
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.14.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -45,6 +45,15 @@
         </dependency>
         <dependency>
             <!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <!--
             TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
              https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
              https://github.com/Netflix/eureka/pull/1572

--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -126,6 +126,7 @@
         </dependency>
 
         <dependency>
+            <!-- Version 3.4.2 has vulnerabilities CVE-2024-25710 and CVE-2024-26308 in org.apache.commons:commons-compress but not relevant as it is a test dependency -->
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>

--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -43,6 +43,16 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+             https://github.com/Netflix/eureka/pull/1572
+             -->
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.21</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/chess-service/pom.xml
+++ b/chess-service/pom.xml
@@ -134,6 +134,7 @@
         </dependency>
 
         <dependency>
+            <!-- Version 3.4.2 has vulnerabilities CVE-2024-25710 and CVE-2024-26308 in org.apache.commons:commons-compress but not relevant as it is a test dependency -->
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>

--- a/chess-service/pom.xml
+++ b/chess-service/pom.xml
@@ -44,6 +44,16 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+             https://github.com/Netflix/eureka/pull/1572
+             -->
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.21</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/chess-service/pom.xml
+++ b/chess-service/pom.xml
@@ -46,6 +46,15 @@
         </dependency>
         <dependency>
             <!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <!--
             TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
              https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
              https://github.com/Netflix/eureka/pull/1572

--- a/fitness-service/pom.xml
+++ b/fitness-service/pom.xml
@@ -113,6 +113,7 @@
         </dependency>
 
         <dependency>
+            <!-- Version 3.4.2 has vulnerabilities CVE-2024-25710 and CVE-2024-26308 in org.apache.commons:commons-compress but not relevant as it is a test dependency -->
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>

--- a/fitness-service/pom.xml
+++ b/fitness-service/pom.xml
@@ -37,6 +37,15 @@
         </dependency>
         <dependency>
             <!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <!--
             TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
              https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
              https://github.com/Netflix/eureka/pull/1572

--- a/fitness-service/pom.xml
+++ b/fitness-service/pom.xml
@@ -35,6 +35,16 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+             https://github.com/Netflix/eureka/pull/1572
+             -->
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.21</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -40,6 +40,16 @@
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>
 		<dependency>
+			<!--
+			TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+			 https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+			 https://github.com/Netflix/eureka/pull/1572
+			 -->
+			<groupId>com.thoughtworks.xstream</groupId>
+			<artifactId>xstream</artifactId>
+			<version>1.4.21</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -41,6 +41,15 @@
 		</dependency>
 		<dependency>
 			<!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.14</version>
+		</dependency>
+		<dependency>
+			<!--
 			TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
 			 https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
 			 https://github.com/Netflix/eureka/pull/1572

--- a/music-service/pom.xml
+++ b/music-service/pom.xml
@@ -113,6 +113,7 @@
         </dependency>
 
         <dependency>
+            <!-- Version 3.4.2 has vulnerabilities CVE-2024-25710 and CVE-2024-26308 in org.apache.commons:commons-compress but not relevant as it is a test dependency -->
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>

--- a/music-service/pom.xml
+++ b/music-service/pom.xml
@@ -37,6 +37,15 @@
         </dependency>
         <dependency>
             <!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <!--
             TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
              https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
              https://github.com/Netflix/eureka/pull/1572

--- a/music-service/pom.xml
+++ b/music-service/pom.xml
@@ -35,6 +35,16 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+             https://github.com/Netflix/eureka/pull/1572
+             -->
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.21</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/registry-service/pom.xml
+++ b/registry-service/pom.xml
@@ -52,6 +52,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+             https://github.com/Netflix/eureka/pull/1572
+             -->
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.21</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/registry-service/pom.xml
+++ b/registry-service/pom.xml
@@ -54,7 +54,16 @@
         </dependency>
         <dependency>
             <!--
-            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-server with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-server with 1.4.21
              https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
              https://github.com/Netflix/eureka/pull/1572
              -->

--- a/usermanagement-library/pom.xml
+++ b/usermanagement-library/pom.xml
@@ -19,10 +19,18 @@
     </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47554 commons-io:2.11.0 in spring-cloud-starter-openfeign with 2.14.0
+             https://www.mend.io/vulnerability-database/CVE-2024-47554?utm_source=JetBrains
+             -->
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.14.0</version>
         </dependency>
 
         <dependency>

--- a/usermanagement-service/pom.xml
+++ b/usermanagement-service/pom.xml
@@ -121,6 +121,7 @@
         </dependency>
 
         <dependency>
+            <!-- Version 3.4.2 has vulnerabilities CVE-2024-25710 and CVE-2024-26308 in org.apache.commons:commons-compress but not relevant as it is a test dependency -->
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-testcontainers</artifactId>
             <scope>test</scope>

--- a/usermanagement-service/pom.xml
+++ b/usermanagement-service/pom.xml
@@ -37,6 +37,16 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+             https://github.com/Netflix/eureka/pull/1572
+             -->
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.21</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/usermanagement-service/pom.xml
+++ b/usermanagement-service/pom.xml
@@ -39,6 +39,15 @@
         </dependency>
         <dependency>
             <!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <!--
             TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
              https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
              https://github.com/Netflix/eureka/pull/1572

--- a/website-service/pom.xml
+++ b/website-service/pom.xml
@@ -48,6 +48,15 @@
         </dependency>
         <dependency>
             <!--
+            TODO Overrides/Fixes CVE-2020-13956 httpclient:4.5.3 in spring-cloud-starter-netflix-eureka-client with 4.5.14
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains
+             -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+        <dependency>
+            <!--
             TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
              https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
              https://github.com/Netflix/eureka/pull/1572

--- a/website-service/pom.xml
+++ b/website-service/pom.xml
@@ -46,6 +46,16 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
         </dependency>
+        <dependency>
+            <!--
+            TODO Overrides/Fixes CVE-2024-47072 xstream:1.4.20 in spring-cloud-starter-netflix-eureka-client with 1.4.21
+             https://www.mend.io/vulnerability-database/CVE-2020-13956?utm_source=JetBrains&query=CVE-2024-47072
+             https://github.com/Netflix/eureka/pull/1572
+             -->
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.21</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Adresses following CVE's:
- CVE-2024-47072
- CVE-2020-13956
- CVE-2024-47554

Not fixes (only used in test dependencies):
- CVE-2024-25710
- CVE-2024-26308