### PR TITLE
Fix incorrect ID mapping in OpeningConverter

### DIFF
--- a/chess-service/src/main/kotlin/com/michibaum/chess_service/app/opening/OpeningConverter.kt
+++ b/chess-service/src/main/kotlin/com/michibaum/chess_service/app/opening/OpeningConverter.kt
@@ -16,7 +16,7 @@ class OpeningConverter {
     
     fun toDto(opening: PopularOpening) =
         PopularOpeningResponseDto(
-            id = opening.id?.toString() ?: "",
+            id = opening.opening.id?.toString() ?: "",
             name = opening.opening.name,
             moveId = opening.opening.lastMove.id?.toString() ?: "",
             ranking = opening.ranking


### PR DESCRIPTION
Corrected the `id` mapping to use `opening.opening.id` instead of `opening.id`. This ensures accurate data conversion when creating `PopularOpeningResponseDto` objects.