### PR TITLE
Remove `condition: service_healthy` from `depends_on`.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,7 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
+      - registry-service
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS}
@@ -50,8 +49,7 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
+      - registry-service
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       DATABASE_USERNAME: ${AUTHENTICATION_DB_USERNAME}
@@ -101,10 +99,8 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
-      usermanagement-db:
-        condition: service_healthy
+      - registry-service
+      - usermanagement-db
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       DATABASE_USERNAME: ${USERMANAGEMENT_DB_USERNAME}
@@ -154,8 +150,7 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
+      - registry-service
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS}
@@ -179,8 +174,7 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
+      - registry-service
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS}
@@ -202,10 +196,8 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
-      chess-db:
-        condition: service_healthy
+      - registry-service
+      - chess-db
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       DATABASE_USERNAME: ${CHESS_DB_USERNAME}
@@ -256,10 +248,8 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
-      fitness-db:
-        condition: service_healthy
+      - registry-service
+      - fitness-db
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       DATABASE_USERNAME: ${FITNESS_DB_USERNAME}
@@ -309,10 +299,8 @@ services:
       - .env
     restart: always
     depends_on:
-      registry-service:
-        condition: service_healthy
-      music-db:
-        condition: service_healthy
+      - registry-service
+      - music-db
     environment:
       spring_profiles_active: ${SPRING_ACTIVE_PROFILES}
       DATABASE_USERNAME: ${MUSIC_DB_USERNAME}


### PR DESCRIPTION
The `condition: service_healthy` option has been deprecated in recent Docker Compose versions. This commit simplifies the `depends_on` configuration to ensure compatibility and avoid potential runtime issues. All references to health-based dependencies have been replaced with a straightforward dependency list.