### PR TITLE
Adjust environment variables and triggers in Writerside workflow

### DIFF
--- a/.github/workflows/writerside.yml
+++ b/.github/workflows/writerside.yml
@@ -5,8 +5,8 @@ on:
     branches: [ "master" ]
 
 env:
-  INSTANCE: 'docs/Writerside/s'
-  DOCKER_VERSION: '2025.03.8312'
+  INSTANCE: 'Writerside/s'
+  DOCKER_VERSION: '243.22562'
 
 jobs:
   build:
@@ -43,6 +43,7 @@ jobs:
       - name: Build docs using Writerside Docker builder
         uses: JetBrains/writerside-github-action@v4
         with:
+          location: 'docs'
           instance: ${{ env.INSTANCE }}
           docker-version: ${{ env.DOCKER_VERSION }}
           artifact: ${{ steps.define-ids.outputs.artifact }}


### PR DESCRIPTION
Updated the Writerside workflow to now solely trigger on the `master` branch, with the `writerside` branch removed from the trigger configuration. The environment variables 'INSTANCE' and 'DOCKER_VERSION' have been modified as well. Additionally, a 'location' parameter has been added to the Writerside Docker builder step for improved control over the workflow.