### PR TITLE
Add year filter to chess events list

### DIFF
--- a/website/src/app/chess/chess-events-list/chess-events-list.component.html
+++ b/website/src/app/chess/chess-events-list/chess-events-list.component.html
@@ -1,3 +1,13 @@
+<p-fieldset [toggleable]="true" [collapsed]="true">
+    <ng-template #header>
+        <p class="text-sm">{{'general.sort' | translate}}</p>
+    </ng-template>
+    <div class="flex flex-wrap gap-4">
+        <p-multiSelect [options]="years()" [(ngModel)]="selectedYears" placeholder="Select Year" styleClass="w-full">
+        </p-multiSelect>
+    </div>
+</p-fieldset>
+
 <div class="grid grid-cols-1 4k:grid-cols-6 xlScreen:grid-cols-5 lScreen:grid-cols-4 desktop:grid-cols-3 laptop:grid-cols-2 tablet:grid-cols-1 mobile:grid-cols-1 gap-4">
 
     <ng-container *ngFor="let category of categoriesAndEventsSorted()">

--- a/website/src/app/chess/chess-events-list/chess-events-list.component.ts
+++ b/website/src/app/chess/chess-events-list/chess-events-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, computed, inject} from '@angular/core';
+import {Component, computed, inject, signal, Signal} from '@angular/core';
 import {ChessService} from "../../core/api-services/chess.service";
 import {CardModule} from "primeng/card";
 import {NgForOf, NgIf} from "@angular/common";
@@ -9,44 +9,72 @@ import {ScrollTopModule} from "primeng/scrolltop";
 import {EventIconPipe} from "../../core/pipes/event-icon.pipe";
 import {EventIconColorPipe} from "../../core/pipes/event-icon-color.pipe";
 import {rxResource} from "@angular/core/rxjs-interop";
+import {Fieldset} from "primeng/fieldset";
+import {TranslatePipe} from "@ngx-translate/core";
+import {MultiSelect} from "primeng/multiselect";
+import {FormsModule} from "@angular/forms";
+import {ChessEventCategoryWithEvents} from "../../core/models/chess/chess.models";
 
 @Component({
   selector: 'app-chess-events-list',
-  imports: [
-    CardModule,
-    NgForOf,
-    RouterLink,
-    TimelineModule,
-    FaIconComponent,
-    ScrollTopModule,
-    NgIf,
-    EventIconPipe,
-    EventIconColorPipe
-  ],
+    imports: [
+        CardModule,
+        NgForOf,
+        RouterLink,
+        TimelineModule,
+        FaIconComponent,
+        ScrollTopModule,
+        NgIf,
+        EventIconPipe,
+        EventIconColorPipe,
+        Fieldset,
+        TranslatePipe,
+        MultiSelect,
+        FormsModule
+    ],
   templateUrl: './chess-events-list.component.html',
   styleUrl: './chess-events-list.component.scss'
 })
 export class ChessEventsListComponent {
   private readonly chessService = inject(ChessService);
 
-
   categories = rxResource({
-    loader: () => this.chessService.eventCategoriesWithEvents()
+    loader: () => this.chessService.eventCategoriesWithEvents(),
+    defaultValue: []
   })
-  categoriesSorted = computed(() => {
-    const _categories = this.categories.value()
-    if(_categories == undefined) return []
-    return _categories.sort((a, b) => a.title.localeCompare(b.title))
+  categoriesFilteredAndSorted = computed(() => {
+    const categories = this.categories.value()
+    const _categories = JSON.parse(JSON.stringify(categories)) as ChessEventCategoryWithEvents[] // deeeeep copy
+    return _categories
+        .sort((a, b) => a.title.localeCompare(b.title))
   })
   categoriesAndEventsSorted = computed(() => {
-    const _categoriesSorted = this.categoriesSorted()
-    if(_categoriesSorted == undefined) return []
+    const categoriesSorted: ChessEventCategoryWithEvents[] = this.categoriesFilteredAndSorted()
+    const yearsSelected = this.selectedYears()
+    const _categoriesSorted = JSON.parse(JSON.stringify(categoriesSorted)) as ChessEventCategoryWithEvents[] // deeeeep copy
     return _categoriesSorted.map(category => {
       if (category.events) {
+        category.events = category.events.filter(event => {
+            if (yearsSelected.length == 0) return true;
+            let eventYear = event.dateFrom?.substring(0, 4);
+            if(eventYear == undefined) return true;
+            return yearsSelected.includes(eventYear);
+        })
         category.events = this.chessService.sortEvents(category.events)
       }
       return category
     })
   })
+  years: Signal<string[]> = computed(() => {
+      const categories = this.categories.value()
+      if(categories == undefined) return []
+      return categories.flatMap(value => value.events)
+          .map(value => value.dateFrom)
+          .filter(value => value != undefined)
+          .map(value => value.substring(0, 4))
+          .filter((value, index, array) => array.indexOf(value) === index)
+          .sort((a, b) => b.localeCompare(a));
+  });
+  selectedYears = signal<string[]>([]);
 
 }


### PR DESCRIPTION
Introduced a year-based filtering feature for chess events using a multi-select dropdown. Updated the component logic and template to support filtering and sorting categories and events by selected years. Enhanced sorting and model management for improved functionality.