### PR TITLE
Bugfix: Set Kotlin plugin version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <jvmTarget>${kotlin.compiler.jvmTarget}</jvmTarget>


### PR DESCRIPTION
Added `${kotlin.version}` to explicitly specify the Kotlin plugin version. This ensures better clarity and consistency in the build configuration.