### PR TITLE
Remove embedded iframe and associated chess.com tab logic

### DIFF
--- a/website/src/app/chess/chess-event/chess-event.component.css
+++ b/website/src/app/chess/chess-event/chess-event.component.css
@@ -1,7 +1,0 @@
-iframe{
-  display: block;  /* iframes are inline by default */
-  height: 77vh;  /* Set height to 100% of the viewport height */
-  width: 100%;  /* Set width to 100% of the viewport width */
-  border: none; /* Remove default border */
-  overflow: hidden;
-}

--- a/website/src/app/chess/chess-event/chess-event.component.html
+++ b/website/src/app/chess/chess-event/chess-event.component.html
@@ -3,12 +3,7 @@
       <p-tab value="0">
         {{'chess.event.details' | translate}}
       </p-tab>
-      <p-tab value="1" [disabled]="embedUrl() == undefined">
-        <p-avatar image="https://www.chess.com/bundles/web/favicons/favicon.5d6cb047.svg" shape="circle" />
-
-        {{'chess.event.chess-com' | translate}}
-      </p-tab>
-      <p-tab value="2" [disabled]="gamesTabDisabled()">
+      <p-tab value="1" [disabled]="gamesTabDisabled()">
         {{'chess.event.games' | translate}}
       </p-tab>
     </p-tablist>
@@ -45,11 +40,6 @@
 
       </p-tabpanel>
       <p-tabpanel value="1">
-
-        <iframe style="border:0;" [src]="embedUrl()" scrolling="no"></iframe>
-
-      </p-tabpanel>
-      <p-tabpanel value="2">
 
         <app-chess-event-games *ngIf="event()" [event]="event()" (haveContent)="gamesTabDisabled.set(!$event)"></app-chess-event-games>
 

--- a/website/src/app/chess/chess-event/chess-event.component.ts
+++ b/website/src/app/chess/chess-event/chess-event.component.ts
@@ -1,5 +1,4 @@
 import {Component, computed, inject, OnInit, Signal, signal, WritableSignal} from '@angular/core';
-import {DomSanitizer, SafeResourceUrl} from "@angular/platform-browser";
 import {ActivatedRoute} from '@angular/router';
 import {CardModule} from "primeng/card";
 import {Button} from "primeng/button";
@@ -11,7 +10,6 @@ import {ChessEventParticipantsComponent} from "./chess-event-participants/chess-
 import {ChessEventGamesComponent} from "./chess-event-games/chess-event-games.component";
 import {DividerModule} from "primeng/divider";
 import {TabsModule} from "primeng/tabs";
-import {Avatar} from "primeng/avatar";
 import {ChessEvent} from "../../core/models/chess/chess.models";
 
 @Component({
@@ -26,26 +24,16 @@ import {ChessEvent} from "../../core/models/chess/chess.models";
     ChessEventGamesComponent,
     DividerModule,
     TabsModule,
-    Avatar,
   ],
   templateUrl: './chess-event.component.html',
   styleUrl: './chess-event.component.css'
 })
 export class ChessEventComponent implements OnInit {
-  private _sanitizer = inject(DomSanitizer);
   private readonly route = inject(ActivatedRoute);
   private readonly navigationService = inject(RouterNavigationService);
 
   event: WritableSignal<ChessEvent | undefined> = signal(undefined)
 
-  embedUrl: Signal<SafeResourceUrl | undefined> = computed(() => {
-    const event = this.event();
-    if(event == undefined)
-      return undefined
-    if(event.embedUrl == undefined || event.embedUrl == "")
-      return undefined
-    return this._sanitizer.bypassSecurityTrustResourceUrl(event.embedUrl)
-  })
   categories: Signal<string> = computed(() => {
     const event = this.event();
     if(event == undefined)

--- a/website/src/assets/i18n/de.json
+++ b/website/src/assets/i18n/de.json
@@ -50,7 +50,6 @@
         "event": {
             "account": "Account",
             "birthday": "Geburtstag",
-            "chess-com": "Chess.com",
             "date-from": "Von",
             "date-to": "Bis",
             "details": "Details",

--- a/website/src/assets/i18n/en.json
+++ b/website/src/assets/i18n/en.json
@@ -50,7 +50,6 @@
         "event": {
             "account": "Account",
             "birthday": "Birthday",
-            "chess-com": "Chess.com",
             "date-from": "From",
             "date-to": "Until",
             "details": "Details",

--- a/website/src/assets/i18n/es.json
+++ b/website/src/assets/i18n/es.json
@@ -50,7 +50,6 @@
         "event": {
             "account": "Cuenta",
             "birthday": "Fecha de nacimiento",
-            "chess-com": "Chess.com",
             "date-from": "Desde",
             "date-to": "Hasta",
             "details": "Detalles",

--- a/website/src/assets/i18n/zh.json
+++ b/website/src/assets/i18n/zh.json
@@ -50,7 +50,6 @@
         "event": {
             "account": "账户",
             "birthday": "生日",
-            "chess-com": "Chess.com",
             "date-from": "从",
             "date-to": "至",
             "details": "详情",


### PR DESCRIPTION
The commit removes the iframe functionality and related chess.com tab logic from the chess-event component. This includes CSS styling, sanitization logic, and template references. The code is now streamlined, focusing only on the remaining event details and games tabs.