### PR TITLE
Remove unused cloud discovery configuration.

### DIFF
--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -23,12 +23,6 @@ spring:
       client:
         username: ${ADMIN_SERVICE_USERNAME}
         password: ${ADMIN_SERVICE_PASSWORD}
-  cloud:
-    discovery:
-      client:
-        simple:
-          local:
-            secure: true
   microservices:
     discord:
       enabled: true


### PR DESCRIPTION
The cloud discovery 'simple' client configuration was removed from the production application.yml file as it is no longer in use. This change simplifies the configuration and removes redundant settings.