### PR TITLE
Rename parameter and add configuration properties

### DIFF
--- a/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/config/AdminClientServletApplicationFactory.kt
+++ b/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/config/AdminClientServletApplicationFactory.kt
@@ -19,7 +19,7 @@ class AdminClientServletApplicationFactory(
     servletContext: ServletContext,
     pathMappedEndpoints: PathMappedEndpoints,
     webEndpoint: WebEndpointProperties,
-    metadataContributors: MetadataContributor,
+    metadataContributor: MetadataContributor,
     dispatcherServletPath: DispatcherServletPath
 ) : ServletApplicationFactory(
     instance,
@@ -28,7 +28,7 @@ class AdminClientServletApplicationFactory(
     servletContext,
     pathMappedEndpoints,
     webEndpoint,
-    metadataContributors,
+    metadataContributor,
     dispatcherServletPath
 ) {
 

--- a/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/config/AdminClientServletApplicationFactoryConfiguration.kt
+++ b/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/config/AdminClientServletApplicationFactoryConfiguration.kt
@@ -1,7 +1,7 @@
 package com.michibaum.gatewayservice.config
 
+import de.codecentric.boot.admin.client.config.ClientProperties
 import de.codecentric.boot.admin.client.config.InstanceProperties
-import de.codecentric.boot.admin.client.config.SpringBootAdminClientAutoConfiguration
 import de.codecentric.boot.admin.client.registration.ApplicationFactory
 import de.codecentric.boot.admin.client.registration.metadata.CompositeMetadataContributor
 import de.codecentric.boot.admin.client.registration.metadata.MetadataContributor
@@ -10,17 +10,19 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints
-import org.springframework.boot.autoconfigure.AutoConfigureBefore
 import org.springframework.boot.autoconfigure.web.ServerProperties
 import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletPath
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 
 @Configuration
-@AutoConfigureBefore(value = [SpringBootAdminClientAutoConfiguration.ServletConfiguration::class])
+@EnableConfigurationProperties(ClientProperties::class, InstanceProperties::class, ServerProperties::class, ManagementServerProperties::class)
 class AdminClientServletApplicationFactoryConfiguration {
     
     @Bean
+    @Primary
     fun applicationFactory(
         instance: InstanceProperties,
         management: ManagementServerProperties,


### PR DESCRIPTION
Renamed `metadataContributors` to `metadataContributor` for consistency and clarity. Added `@EnableConfigurationProperties` and marked `applicationFactory` as `@Primary` to enhance configuration alignment and prioritize the factory bean.