### PR TITLE
Add @AutoConfigureBefore annotation to configuration class

### DIFF
--- a/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/config/AdminClientServletApplicationFactoryConfiguration.kt
+++ b/gateway-service/src/main/kotlin/com/michibaum/gatewayservice/config/AdminClientServletApplicationFactoryConfiguration.kt
@@ -2,6 +2,7 @@ package com.michibaum.gatewayservice.config
 
 import de.codecentric.boot.admin.client.config.ClientProperties
 import de.codecentric.boot.admin.client.config.InstanceProperties
+import de.codecentric.boot.admin.client.config.SpringBootAdminClientAutoConfiguration
 import de.codecentric.boot.admin.client.registration.ApplicationFactory
 import de.codecentric.boot.admin.client.registration.metadata.CompositeMetadataContributor
 import de.codecentric.boot.admin.client.registration.metadata.MetadataContributor
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
 import org.springframework.boot.autoconfigure.web.ServerProperties
 import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletPath
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -19,6 +21,7 @@ import org.springframework.context.annotation.Primary
 
 @Configuration
 @EnableConfigurationProperties(ClientProperties::class, InstanceProperties::class, ServerProperties::class, ManagementServerProperties::class)
+@AutoConfigureBefore(value = [SpringBootAdminClientAutoConfiguration.ServletConfiguration::class])
 class AdminClientServletApplicationFactoryConfiguration {
     
     @Bean


### PR DESCRIPTION
This change ensures that AdminClientServletApplicationFactoryConfiguration is loaded before SpringBootAdminClientAutoConfiguration.ServletConfiguration. It improves the configuration order, preventing potential misconfigurations during application startup.