### PR TITLE
Bump dependency versions in `pom.xml`:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,23 +15,23 @@
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
         https://github.com/spring-projects/spring-boot/wiki
         -->
-        <spring-boot.version>4.0.3</spring-boot.version>
+        <spring-boot.version>4.0.7</spring-boot.version>
 
         <!--
         https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
         https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions#supported-releases
         -->
-        <spring-cloud.version>2025.1.1</spring-cloud.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
 
         <!--
         https://mvnrepository.com/artifact/de.codecentric/spring-boot-admin-server
         https://github.com/codecentric/spring-boot-admin/
         -->
-        <spring-boot-admin.version>4.0.2</spring-boot-admin.version>
+        <spring-boot-admin.version>4.1.1</spring-boot-admin.version>
 
         <!-- https://mvnrepository.com/artifact/net.ttddyy.observation/datasource-micrometer-spring-boot -->
         <!-- https://github.com/jdbc-observations/datasource-micrometer -->
-        <datasource-micrometer-spring-boot.version>2.1.1</datasource-micrometer-spring-boot.version>
+        <datasource-micrometer-spring-boot.version>2.2.1</datasource-micrometer-spring-boot.version>
         <!-- https://mvnrepository.com/artifact/io.micrometer/micrometer-bom -->
         <micrometer-bom.version>1.16.6</micrometer-bom.version>
 
@@ -44,15 +44,15 @@
         https://stackoverflow.com/a/77179226/10258204
         https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
         -->
-        <kotlin.version>2.3.10</kotlin.version>
-        <kotlin-coroutines.version>1.10.2</kotlin-coroutines.version>
+        <kotlin.version>2.3.21</kotlin.version>
+        <kotlin-coroutines.version>1.11.0</kotlin-coroutines.version>
         <kotlin.compiler.jvmTarget>25</kotlin.compiler.jvmTarget>
 
         <!--
         https://mockk.io/
         https://mvnrepository.com/artifact/io.mockk/mockk-jvm
         -->
-        <mockk.version>1.14.6</mockk.version>
+        <mockk.version>1.14.11</mockk.version>
 
         <!-- Docker Hub -->
         <dockerHub.url>https://registry.hub.docker.com</dockerHub.url>
@@ -62,7 +62,7 @@
         <!-- https://mvnrepository.com/artifact/com.google.cloud.tools/jib-maven-plugin -->
         <jib-maven-plugin.version>3.5.1</jib-maven-plugin.version>
         <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <!-- https://github.com/aleksandr-m/gitflow-maven-plugin -->
         <gitflow-plugin.version>1.21.0</gitflow-plugin.version>
     </properties>
@@ -158,6 +158,11 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>repository.spring.release</id>
+            <name>Spring GA Repository</name>
+            <url>https://repo.spring.io/release</url>
         </repository>
         <repository>
             <id>repository.spring.milestone</id>


### PR DESCRIPTION
- Spring Boot to 4.0.7
- Spring Cloud to 2025.1.2
- Spring Boot Admin to 4.1.1
- Micrometer Datasource to 2.2.1
- Kotlin to 2.3.21
- Kotlin Coroutines to 1.11.0
- MockK to 1.14.11
- Jacoco Maven Plugin to 0.8.15