### PR TITLE
Upgrade Java version to 26 and dependencies across the project

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v5.0.0
         with:
           distribution: 'temurin'
-          java-version: '25'
+          java-version: '26'
           cache: 'maven'
           cache-dependency-path: |
             **/pom.xml

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -20,11 +20,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2025.3
+        uses: JetBrains/qodana-action@v2026.1
         with:
           pr-mode: false
           args: >
-            --image,jetbrains/qodana-jvm-community:2025.3,
+            --image,jetbrains/qodana-jvm-community:2026.1,
             --linter,qodana-jvm-community
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_201545685 }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '25'
+          java-version: '26'
           cache: 'maven'
           cache-dependency-path: |
             **/pom.xml

--- a/.junie/agents/cloud-infrastructure-engineer.md
+++ b/.junie/agents/cloud-infrastructure-engineer.md
@@ -16,7 +16,7 @@ You are a cloud infrastructure engineer responsible for the deployment, containe
 - Update CI/CD pipelines (GitHub Actions) for automated builds and deployments.
 
 ### Infrastructure Rules
-- **Base Images**: Use `eclipse-temurin:25-jre-alpine` for all JVM service containers.
+- **Base Images**: Use `eclipse-temurin:26-jre-alpine` for all JVM service containers.
 - **Non-Root Containers**: All containers must run as a non-root user.
 - **Resource Limits**: Define CPU and memory requests/limits for all Kubernetes workloads.
 - **Health Checks**: Every service must have `livenessProbe` and `readinessProbe` configured.

--- a/.junie/skills/infrastructure-tooling/SKILL.md
+++ b/.junie/skills/infrastructure-tooling/SKILL.md
@@ -31,7 +31,7 @@ description: "Proficiency in local development environment, CLI tools, Docker Co
 - `docker-compose.local.yml` defines the local development stack (databases, services).
 - Use `docker-compose -f docker-compose.local.yml up -d` to start all infrastructure.
 - Use `docker-compose -f docker-compose.local.yml down` to stop and clean up.
-- Dockerfiles should use `eclipse-temurin:25-jre-alpine` as the base image for services.
+- Dockerfiles should use `eclipse-temurin:26-jre-alpine` as the base image for services.
 
 ## Terminal Environment
 - This project runs on Windows; use PowerShell syntax for all terminal commands.

--- a/.junie/skills/kotlin-spring-mastery/SKILL.md
+++ b/.junie/skills/kotlin-spring-mastery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "kotlin-spring-mastery"
-description: "Expertise in Kotlin 2.3+, Spring Boot 4.0+, and Java 25 development. Use when writing or reviewing backend Kotlin code, configuring Spring Boot services, or managing Maven dependencies."
+description: "Expertise in Kotlin 2.4+, Spring Boot 4.1+, and Java 26 development. Use when writing or reviewing backend Kotlin code, configuring Spring Boot services, or managing Maven dependencies."
 ---
 # Kotlin & Spring Mastery
 
@@ -11,9 +11,9 @@ description: "Expertise in Kotlin 2.3+, Spring Boot 4.0+, and Java 25 developmen
 - Reviewing Kotlin code for idiomatic patterns and best practices.
 
 ## Technology Stack
-- **Kotlin 2.3+** as the primary language for all backend services.
-- **Java 25** as the JVM target.
-- **Spring Boot 4.0+** for application framework.
+- **Kotlin 2.4+** as the primary language for all backend services.
+- **Java 26** as the JVM target.
+- **Spring Boot 4.1+** for application framework.
 - **Spring Cloud 2025.x** for distributed systems patterns.
 - **Maven** for build and dependency management.
 

--- a/.junie/skills/kubernetes-expert/SKILL.md
+++ b/.junie/skills/kubernetes-expert/SKILL.md
@@ -28,7 +28,7 @@ description: "Expertise in Kubernetes (k0s) deployments, orchestration, and cont
 - Define `Service` resources with appropriate port mappings for each microservice.
 
 ## Container Best Practices
-- Use `eclipse-temurin:25-jre-alpine` as the base image for JVM services.
+- Use `eclipse-temurin:26-jre-alpine` as the base image for JVM services.
 - Keep Docker images minimal; use multi-stage builds where appropriate.
 - Do not run containers as root; use a non-root user in Dockerfiles.
 - Tag images with specific versions; avoid `latest` tag in production manifests.

--- a/.run/All ArchitectureTests.run.xml
+++ b/.run/All ArchitectureTests.run.xml
@@ -12,7 +12,7 @@
       </ENTRIES>
     </extension>
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-25" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-26" />
     <option name="PACKAGE_NAME" value="com.michibaum" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/.run/All Project Tests.run.xml
+++ b/.run/All Project Tests.run.xml
@@ -12,7 +12,7 @@
       </ENTRIES>
     </extension>
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-25" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-26" />
     <option name="PACKAGE_NAME" value="com.michibaum" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/.run/All UT.run.xml
+++ b/.run/All UT.run.xml
@@ -12,7 +12,7 @@
       </ENTRIES>
     </extension>
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-25" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-26" />
     <option name="PACKAGE_NAME" value="com.michibaum" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/admin-service/pom.xml
+++ b/admin-service/pom.xml
@@ -13,8 +13,8 @@
 	<name>admin-service</name>
 
 	<properties>
-		<maven.compiler.source>25</maven.compiler.source>
-		<maven.compiler.target>25</maven.compiler.target>
+  <maven.compiler.source>26</maven.compiler.source>
+  <maven.compiler.target>26</maven.compiler.target>
 		<xstream.version>1.4.21</xstream.version>
 	</properties>
 

--- a/archunittests/pom.xml
+++ b/archunittests/pom.xml
@@ -14,8 +14,8 @@
     <name>archunittests</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         
         <archunit.version>1.4.1</archunit.version>
     </properties>

--- a/authentication-library/pom.xml
+++ b/authentication-library/pom.xml
@@ -15,8 +15,8 @@
     <name>authentication-library</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -14,8 +14,8 @@
     <name>authentication-service</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/chess-play-library/pom.xml
+++ b/chess-play-library/pom.xml
@@ -15,8 +15,8 @@
     <name>chess-play-library</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/chess-service/pom.xml
+++ b/chess-service/pom.xml
@@ -15,8 +15,8 @@
     <name>chess-service</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/docs/Writerside/topics/Development.md
+++ b/docs/Writerside/topics/Development.md
@@ -1,7 +1,7 @@
 # Development
 
 Requirements:
-- Java 25 installed
+- Java 26 installed
 - Npm installed (lts is best)
 - [Update hosts file](#update-hosts-file)
 - Local dev database

--- a/fitness-service/pom.xml
+++ b/fitness-service/pom.xml
@@ -12,8 +12,8 @@
     <name>fitness-service</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/gateway-service/pom.xml
+++ b/gateway-service/pom.xml
@@ -14,8 +14,8 @@
 	<name>gateway-service</name>
 
 	<properties>
-		<maven.compiler.source>25</maven.compiler.source>
-		<maven.compiler.target>25</maven.compiler.target>
+  <maven.compiler.source>26</maven.compiler.source>
+  <maven.compiler.target>26</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/music-service/pom.xml
+++ b/music-service/pom.xml
@@ -12,8 +12,8 @@
     <name>music-service</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/permission-library/pom.xml
+++ b/permission-library/pom.xml
@@ -13,8 +13,8 @@
     <name>permission-library</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -36,17 +36,17 @@
         <micrometer-bom.version>1.17.0</micrometer-bom.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>25</java.version>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <java.version>26</java.version>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
 
         <!--
         https://stackoverflow.com/a/77179226/10258204
         https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
         -->
-        <kotlin.version>2.3.21</kotlin.version>
+        <kotlin.version>2.4.0</kotlin.version>
         <kotlin-coroutines.version>1.11.0</kotlin-coroutines.version>
-        <kotlin.compiler.jvmTarget>25</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>26</kotlin.compiler.jvmTarget>
 
         <!--
         https://mockk.io/
@@ -56,7 +56,7 @@
 
         <!-- Docker Hub -->
         <dockerHub.url>https://registry.hub.docker.com</dockerHub.url>
-        <jib-maven-plugin.image>eclipse-temurin:25-jre-alpine</jib-maven-plugin.image>
+        <jib-maven-plugin.image>eclipse-temurin:26-jre-alpine</jib-maven-plugin.image>
         
         <!-- Plugins -->
         <!-- https://mvnrepository.com/artifact/com.google.cloud.tools/jib-maven-plugin -->

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-jvm:2025.1
+linter: jetbrains/qodana-jvm:2026.1
 profile:
   name: qodana.recommended
 include:

--- a/registry-service/pom.xml
+++ b/registry-service/pom.xml
@@ -14,8 +14,8 @@
     <name>registry-service</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/spring-boot-starter-authentication/pom.xml
+++ b/spring-boot-starter-authentication/pom.xml
@@ -15,8 +15,8 @@
     <name>spring-boot-starter-authentication</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/spring-boot-starter-cache/pom.xml
+++ b/spring-boot-starter-cache/pom.xml
@@ -15,8 +15,8 @@
     <name>spring-boot-starter-cache</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/spring-boot-starter-discord/pom.xml
+++ b/spring-boot-starter-discord/pom.xml
@@ -15,8 +15,8 @@
     <name>spring-boot-starter-discord</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/usermanagement-library/pom.xml
+++ b/usermanagement-library/pom.xml
@@ -14,8 +14,8 @@
     <name>usermanagement-library</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/usermanagement-service/pom.xml
+++ b/usermanagement-service/pom.xml
@@ -14,8 +14,8 @@
     <name>usermanagement-service</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/website-service/pom.xml
+++ b/website-service/pom.xml
@@ -15,8 +15,8 @@
     <name>website-service</name>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
+        <maven.compiler.source>26</maven.compiler.source>
+        <maven.compiler.target>26</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Incremented `maven.compiler.source` and `maven.compiler.target` to 26 in all modules.
- Updated base Docker image to `eclipse-temurin:26-jre-alpine`.
- Bumped Qodana version to 2026.1 and related configurations.
- Upgraded Kotlin to 2.4.0 and adjusted JVM target.
- Updated documentation to reflect Java 26 and related changes.